### PR TITLE
feat: separate logic of mturk, at home, electron - runs in browser

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,19 +1,18 @@
 import React from 'react'
 import { Experiment, jsPsych } from 'jspsych-react'
 import { tl } from './timelines/main'
-import { MTURK } from './config/main'
+import { MTURK, IS_ELECTRON } from './config/main'
 import './App.css'
 import 'bootstrap/dist/css/bootstrap.css'
 import '@fortawesome/fontawesome-free/css/all.css'
 import { getTurkUniqueId, sleep } from './lib/utils'
 
-const isElectron = !MTURK
 let ipcRenderer = false;
 let psiturk = false
-if (isElectron) {
+if (IS_ELECTRON) {
   const electron = window.require('electron');
   ipcRenderer  = electron.ipcRenderer;
-} else {
+} else if (MTURK) {
   /* eslint-disable */
   window.lodash = _.noConflict()
   psiturk = new PsiTurk(getTurkUniqueId(), '/complete')
@@ -48,6 +47,8 @@ class App extends React.Component {
                 psiturk.completeHIT()
               }
               completePsiturk()
+            } else {
+              jsPsych.data.get().localSave('csv','neuro-task.csv');
             }
           },
         }}

--- a/src/config/main.js
+++ b/src/config/main.js
@@ -19,6 +19,13 @@ const keys = {
 // is this mechanical turk?
 const MTURK = (!jsPsych.turk.turkInfo().outsideTurk)
 const AT_HOME = (process.env.REACT_APP_AT_HOME === 'true')
+let IS_ELECTRON = true
+
+try {
+	window.require('electron')
+} catch {
+	IS_ELECTRON = false
+}
 
 // get language file
 const lang = require('../language/en_us.json')
@@ -41,5 +48,6 @@ export {
 	lang,
 	eventCodes,
 	MTURK,
-	AT_HOME
+	AT_HOME,
+	IS_ELECTRON
 }

--- a/src/lib/markup/eventMarkerMessage.js
+++ b/src/lib/markup/eventMarkerMessage.js
@@ -1,12 +1,7 @@
-import { MTURK, lang } from '../../config/main'
+import { lang } from '../../config/main'
 
 const eventMarkerMessage = async () => {
-	if (!MTURK) {
 		return `<span style="color: green;">${lang.eventMarker.found}</span>`
-	}
-	else {
-		return `<span style="color: red;">${lang.eventMarker.not_found}</span>`
-	}
 }
 
 export default eventMarkerMessage

--- a/src/lib/markup/photodiode.js
+++ b/src/lib/markup/photodiode.js
@@ -1,18 +1,17 @@
-import { MTURK, AT_HOME } from  '../../config/main'
+import { AT_HOME, IS_ELECTRON } from  '../../config/main'
 import { eventCodes } from '../../config/trigger'
 import $ from 'jquery'
 
 // conditionally load electron and psiturk based on MTURK config variable
-const isElectron = !MTURK
 let ipcRenderer = false;
-if (isElectron) {
+if (IS_ELECTRON) {
   const electron = window.require('electron');
   ipcRenderer  = electron.ipcRenderer;
 }
 
 // Relies on styling in App.css, generate PD spot
 const photodiodeGhostBox = () => {
-	const class_ = (AT_HOME) ? 'invisible' : 'visible'
+	const class_ = (AT_HOME || !IS_ELECTRON) ? 'invisible' : 'visible'
 
   const markup = `<div class="photodiode-box ${class_}" id="photodiode-box">
 									<span id="photodiode-spot" class="photodiode-spot"></span>
@@ -39,7 +38,7 @@ const pdSpotEncode = (taskCode) => {
       }
     }
 
-		if (!AT_HOME) {
+		if (!AT_HOME && IS_ELECTRON) {
 				const blinkTime = 40
 				let numBlinks = taskCode
 		    if (taskCode < eventCodes.open_task) numBlinks = 1;

--- a/src/timelines/main.js
+++ b/src/timelines/main.js
@@ -2,14 +2,11 @@ import buildCountdown from '../trials/countdown'
 import preamble from './preamble'
 import experimentEnd from '../trials/experimentEnd'
 import taskBlock from './taskBlock'
-import userId from '../trials/userId'
 
 import { MTURK, lang } from '../config/main'
 import { practiceBlock } from '../config/practice'
 import { tutorialBlock } from '../config/tutorial'
 import { exptBlock1, exptBlock2 } from '../config/experiment'
-
-import startCode from '../trials/startCode'
 
 
 const primaryTimeline = [

--- a/src/timelines/preamble.js
+++ b/src/timelines/preamble.js
@@ -2,14 +2,14 @@ import experimentStart from '../trials/experimentStart'
 import startCode from '../trials/startCode'
 import userId from '../trials/userId'
 import holdUpMarker from '../trials/holdUpMarker'
-import { AT_HOME } from '../config/main'
+import { AT_HOME, IS_ELECTRON } from '../config/main'
 
 console.log('at_home', AT_HOME)
 console.log('env at home', process.env.REACT_APP_AT_HOME)
 const preamble = {
   type: 'html_keyboard_response',
   stimulus: '',
-  timeline: (AT_HOME) ?
+  timeline: (AT_HOME || !IS_ELECTRON) ?
     [experimentStart(), userId()] :
     [experimentStart(), userId(), holdUpMarker(), startCode()]
 }

--- a/src/trials/taskEnd.js
+++ b/src/trials/taskEnd.js
@@ -1,4 +1,4 @@
-import { eventCodes, MTURK } from '../config/main'
+import { eventCodes, IS_ELECTRON, AT_HOME } from '../config/main'
 import { earningsDisplay } from '../lib/markup/earnings'
 import { photodiodeGhostBox, pdSpotEncode } from '../lib/markup/photodiode'
 
@@ -14,7 +14,7 @@ const beadEnd = (trialDetails, duration) => {
       on_start: (trial) => {
         let earnings = Math.random()
         trial.stimulus = earningsDisplay(earnings)
-        if (!MTURK) trial.stimulus += photodiodeGhostBox()
+        if (IS_ELECTRON && !AT_HOME) trial.stimulus += photodiodeGhostBox()
       },
       on_finish: (data) => data.code = code
     }


### PR DESCRIPTION
Separate/make explicit logic of at home, electron, and mturk.  Now able to run in the broswer and save a CSV at experiment end if not in electron or mturk modes.