### PR TITLE
Delete .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@brown-ccv:registry=https://npm.pkg.github.com

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "homepage": ".",
   "repository": "https://github.com/brown-ccv/honeycomb",
   "dependencies": {
-    "@brown-ccv/behavioral-task-trials": "^1.26.1",
+    "@brown-ccv/behavioral-task-trials": "^1",
     "@fortawesome/fontawesome-free": "^5.9.0",
     "bootstrap": "^4.3.1",
     "cross-env": "^6.0.3",


### PR DESCRIPTION
The behavioral-task-trials are hosted on npm, not github. So this file breaks install.