### PR TITLE
Electron upgrade

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -68,12 +68,6 @@ jobs:
       - name: package electron - mac
         if: startsWith(matrix.os, 'mac')
         run: npm run package:mac
-      - name: npm rebuild - mac
-        if: startsWith(matrix.os, 'mac')
-        run: npm rebuild
-      - name: Mac installer
-        if: startsWith(matrix.os, 'mac')
-        run: npm run installer:mac
 
       # Upload installers to github action
       - name: upload win-installer
@@ -81,19 +75,19 @@ jobs:
         if: startsWith(matrix.os, 'windows')
         with:
           name: ${{ format('win-installer-{0}', github.event.inputs.setting) }}
-          path: dist/installers/${{ steps.package_info.outputs.package_name }}-${{ steps.package_info.outputs.package_version }}-setup.exe
+          path: out/make/squirrel/x64/${{ steps.package_info.outputs.package_name }}-${{ steps.package_info.outputs.package_version }}-setup.exe
       - name: upload mac-installer
         uses: actions/upload-artifact@master
         if: startsWith(matrix.os, 'mac')
         with:
           name: ${{ format('mac-installer-{0}', github.event.inputs.setting) }}
-          path: dist/installers/${{ steps.package_info.outputs.package_name }}-${{ steps.package_info.outputs.package_version }}.dmg
+          path: out/make/dmg/x64/${{ steps.package_info.outputs.package_name }}-${{ steps.package_info.outputs.package_version }}.dmg
       - name: upload linux-installer
         uses: actions/upload-artifact@master
         if: startsWith(matrix.os, 'ubuntu')
         with:
           name: ${{ format('linux-installer-{0}', github.event.inputs.setting) }}
-          path: dist/installers/${{ steps.package_info.outputs.package_name }}_${{ steps.package_info.outputs.package_version }}_amd64.deb
+          path: out/make/deb/x64/${{ steps.package_info.outputs.package_name }}_${{ steps.package_info.outputs.package_version }}_amd64.deb
 
       # Build PsiTurk - linux only
       - name: Set up Python 3.7

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -75,13 +75,13 @@ jobs:
         if: startsWith(matrix.os, 'windows')
         with:
           name: ${{ format('win-installer-{0}', github.event.inputs.setting) }}
-          path: out/make/squirrel/x64/${{ steps.package_info.outputs.package_name }}-${{ steps.package_info.outputs.package_version }}-setup.exe
+          path: out/make/squirrel.windows/x64/${{ steps.package_info.outputs.package_name }}-${{ steps.package_info.outputs.package_version }} Setup.exe
       - name: upload mac-installer
         uses: actions/upload-artifact@master
         if: startsWith(matrix.os, 'mac')
         with:
           name: ${{ format('mac-installer-{0}', github.event.inputs.setting) }}
-          path: out/make/dmg/x64/${{ steps.package_info.outputs.package_name }}-${{ steps.package_info.outputs.package_version }}.dmg
+          path: out/make/${{ steps.package_info.outputs.package_name }}-${{ steps.package_info.outputs.package_version }}-x64.dmg
       - name: upload linux-installer
         uses: actions/upload-artifact@master
         if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,21 +58,14 @@ jobs:
       - name: package electron - mac
         if: startsWith(matrix.os, 'mac')
         run: npm run package:mac
-      - name: npm rebuild - mac
-        if: startsWith(matrix.os, 'mac')
-        run: npm rebuild
-      - name: Mac installer
-        if: startsWith(matrix.os, 'mac')
-        run: npm run installer:mac
 
       # Upload installers to github release
-
       - name: Upload app to release - windows
         if: startsWith(matrix.os, 'windows')
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: dist/installers/${{ steps.package_info.outputs.package_name }}-${{ steps.package_info.outputs.package_version }}-setup.exe
+          file: out/make/squirrel/x64/${{ steps.package_info.outputs.package_name }}-${{ steps.package_info.outputs.package_version }}-setup.exe
           asset_name: ${{ steps.package_info.outputs.package_name }}-${{ steps.package_info.outputs.package_version }}-${{ matrix.setting }}-setup.exe
           tag: ${{ github.ref }}
       - name: Upload app to release - linux
@@ -80,7 +73,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: dist/installers/${{ steps.package_info.outputs.package_name }}_${{ steps.package_info.outputs.package_version }}_amd64.deb
+          file: out/make/deb/x64/${{ steps.package_info.outputs.package_name }}_${{ steps.package_info.outputs.package_version }}_amd64.deb
           asset_name: ${{ steps.package_info.outputs.package_name }}_${{ steps.package_info.outputs.package_version }}_${{ matrix.setting }}_amd64.deb
           tag: ${{ github.ref }}
       - name: Upload app to release - mac
@@ -88,7 +81,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: dist/installers/${{ steps.package_info.outputs.package_name }}-${{ steps.package_info.outputs.package_version }}.dmg
+          file: out/make/dmg/x64/${{ steps.package_info.outputs.package_name }}-${{ steps.package_info.outputs.package_version }}.dmg
           asset_name: ${{ steps.package_info.outputs.package_name }}-${{ steps.package_info.outputs.package_version }}-${{ matrix.setting }}.dmg
           tag: ${{ github.ref }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: out/make/squirrel/x64/${{ steps.package_info.outputs.package_name }}-${{ steps.package_info.outputs.package_version }}-setup.exe
+          file: out/make/squirrel.windows/x64/${{ steps.package_info.outputs.package_name }}-${{ steps.package_info.outputs.package_version }} Setup.exe
           asset_name: ${{ steps.package_info.outputs.package_name }}-${{ steps.package_info.outputs.package_version }}-${{ matrix.setting }}-setup.exe
           tag: ${{ github.ref }}
       - name: Upload app to release - linux
@@ -82,7 +82,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: out/make/dmg/x64/${{ steps.package_info.outputs.package_name }}-${{ steps.package_info.outputs.package_version }}.dmg
-          asset_name: ${{ steps.package_info.outputs.package_name }}-${{ steps.package_info.outputs.package_version }}-${{ matrix.setting }}.dmg
+          out/make/${{ steps.package_info.outputs.package_name }}-${{ steps.package_info.outputs.package_version }}-x64.dmg
           tag: ${{ github.ref }}
 
       # Update github pages - linux only

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 # production
 /build
 /dist
+/out
 
 # misc
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@brown-ccv/behavioral-task-trials": "^2.0.0",
     "@fortawesome/fontawesome-free": "^5.9.0",
     "bootstrap": "^5.2.0-beta1",
-    "electron-log": "^3.0.9",
+    "electron-log": "^4.4.8",
     "electron-squirrel-startup": "^1.0.0",
     "event-marker": "git+https://github.com/brown-ccv/event-marker.git",
     "execa": "^5.0.0",
@@ -73,6 +73,27 @@
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
+    },
+    "forge": {
+      "packagerConfig": {},
+      "makers": [
+        {
+          "name": "@electron-forge/maker-deb",
+          "config": {}
+        },
+        {
+          "name": "@electron-forge/maker-dmg",
+          "platforms": [
+            "darwin"
+          ]
+        },
+        {
+          "name": "@electron-forge/maker-squirrel",
+          "config": {
+            "name": "electron_test"
+          }
+        }
+      ]
     }
   },
   "browserslist": {
@@ -95,21 +116,17 @@
     "cz-conventional-changelog": "^3.2.0",
     "dotenv": "^8.2.0",
     "dotenv-cli": "^4.0.0",
-    "electron": "6.1.1",
-    "electron-devtools-installer": "^3.2.0",
-    "electron-packager": "^14.0.6",
-    "electron-rebuild": "^3.2.7",
     "firebase-tools": "^11.0.1",
-    "require-context.macro": "^1.1.1"
+    "require-context.macro": "^1.1.1",
+    "@electron-forge/cli": "^6.0.0-beta.64",
+    "@electron-forge/maker-deb": "^6.0.0-beta.64",
+    "@electron-forge/maker-dmg": "^6.0.0-beta.64",
+    "@electron-forge/maker-squirrel": "^6.0.0-beta.64",
+    "electron": "19.0.8"
   },
   "babel": {
     "plugins": [
       "macros"
     ]
-  },
-  "optionalDependencies": {
-    "electron-installer-debian": "^2.0.0",
-    "electron-installer-dmg": "^3.0.0",
-    "electron-installer-windows": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,12 +44,9 @@
     "test": "react-scripts test",
     "prebuild": "electron-rebuild",
     "build": "react-scripts build",
-    "package:windows": "electron-packager . --platform win32 --arch x64 --icon ./assets/icons/win/icon.ico --out dist/ --overwrite --asar ",
-    "package:mac": "electron-packager . --platform darwin --arch x64 --out dist/ --icon ./assets/icons/mac/icon.icns --overwrite",
-    "package:linux": "electron-packager . --platform linux --arch x64 --icon ./assets/icons/mac/icon.icns --out dist/ --overwrite",
-    "postpackage:windows": "electron-installer-windows --src dist/%npm_package_name%-win32-x64/ --dest dist/installers/ --overwrite --homepage https://ccv.brown.edu/",
-    "postpackage:linux": "electron-installer-debian --src dist/${npm_package_name}-linux-x64/ --dest dist/installers/ --arch amd64 --overwrite",
-    "installer:mac": "electron-installer-dmg ./dist/${npm_package_name}-darwin-x64/${npm_package_name}.app ${npm_package_name}-${npm_package_version} --out ./dist/installers/ --icon ./assets/icons/mac/icon.icns --overwrite",
+    "package:windows": "react-scripts build && electron-forge make --arch x64 --targets @electron-forge/maker-squirrel",
+    "package:linux": "react-scripts build && electron-forge make --arch x64 --targets @electron-forge/maker-deb",
+    "package:mac": "react-scripts build && electron-forge make --arch x64 --targets @electron-forge/maker-dmg",
     "rebuild": "electron-rebuild",
     "eject": "react-scripts eject",
     "electron": "electron .",
@@ -75,14 +72,22 @@
       "path": "./node_modules/cz-conventional-changelog"
     },
     "forge": {
-      "packagerConfig": {},
+      "packagerConfig": {
+        "asar": true
+      },
       "makers": [
         {
           "name": "@electron-forge/maker-deb",
-          "config": {}
+          "config": {
+            "icon": "./assets/icons/mac/icon.icns"
+          }
         },
         {
           "name": "@electron-forge/maker-dmg",
+          "config": {
+            "icon": "./assets/icons/mac/icon.icns",
+            "overwrite": true
+          },
           "platforms": [
             "darwin"
           ]
@@ -90,7 +95,7 @@
         {
           "name": "@electron-forge/maker-squirrel",
           "config": {
-            "name": "electron_test"
+            "iconUrl": "./assets/icons/win/icon.ico"
           }
         }
       ]

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
         {
           "name": "@electron-forge/maker-squirrel",
           "config": {
-            "iconUrl": "./assets/icons/win/icon.ico"
+            "iconUrl": "https://raw.githubusercontent.com/brown-ccv/honeycomb/main/assets/icons/win/icon.ico"
           }
         }
       ]

--- a/public/electron.js
+++ b/public/electron.js
@@ -2,7 +2,6 @@
 if(require('electron-squirrel-startup')) return 
 
 // Modules to control application life and create native browser window
-const imageKeyboardResponse = require('@jspsych/plugin-html-keyboard-response')
 const { app, BrowserWindow, dialog } = require('electron')
 const path = require('path')
 const ipc = require('electron').ipcMain
@@ -238,7 +237,7 @@ ipc.on('data', (event, args) => {
     stream.write(JSON.stringify({...args, git}))
 
     // Copy provocation images to participant's data folder
-    if (args.trial_type === imageKeyboardResponse) images.push(args.stimulus.slice(7))
+    if (args.trial_type === "image-keyboard-response") images.push(args.stimulus.slice(7))
   }
 })
 


### PR DESCRIPTION
Greetings!  Here's a PR to upgrade honeycomb to use the latest electron and electron-forge tooling.  This is intended to close #92 .

I ran through the electron-forge [Getting Started](https://www.electronforge.io/) docs to learn what are the official recommended dependencies and config for electron these days.  Then I tried to map these back to the honeycomb project and replace our older dependencies with those official recommendations.

All the existing honeycomb build scripts should still run.  The only scripts that needed major changes were for the actual package/postpackage.  The new style seems to be simpler scripts, and a bunch of new "forge" config in package.json.

Running locally on Linux, I was able to `package:linux` and get a deb package created and installed.  I was able to run it and play through the demo task!

Using GitHub actions, I was also able to create and "release" packages for mac and win ([on my own hacked-up honeycomb repo](https://github.com/benjamin-heasly/hello-honeycomb/releases/tag/test12)).  I tried the dmg on my iMac and it also worked!

I don't have a Windows machine to test with, so I'm less sure about that one.

The new electron-forge "Makers" create output files with slightly different names than before, and there seems not to be a way to specify the output folder or names.  So I updated the GitHub actions to match the new names.  I ran into one slight issue with hyphens vs underscores in the created file names on win32, so I created an issue over at [gh-actions](https://github.com/brown-ccv/gh-actions/issues/39).