### PR TITLE
Use same startDate value between renders, for Login and JsPsychExperiment

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,8 +12,11 @@ import { initParticipant, addToFirebase } from './firebase'
 import { config, taskVersion, turkUniqueId } from './config/main'
 
 function App () {
-  // Variables for time
-  const startDate = new Date().toISOString()
+  // Remember startDate between renders.
+  // This is necessary to allow Firebase to create a timestamped document at Login time,
+  // and then to find and update the *same* timestamped document after each trial in JsPsychExperiment.
+  const [startDate] = useState(new Date().toISOString())
+
   // Variables for login
   const [loggedIn, setLogin] = useState(false)
   const [ipcRenderer, setRenderer] = useState(false)


### PR DESCRIPTION
Fixes a bug I introduced with jspsych 7, where Login and JsPsychExperiment got different values of
startDate, breaking Firebase document updates.

I found this while doing more testing, on a Honeycomb pilot project with the Nassar lab.