### PR TITLE
ci(node): build actions use node 16 to support electron-forge upgrade

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 16.x
 
       # install, test, build package
       - name: npm install

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 16.x
       - name: Set package version and name
         uses: brown-ccv/gh-actions/get-package-info@main
         id: package_info

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 16.x
       - name: Set package version and name
         uses: brown-ccv/gh-actions/get-package-info@main
         id: package_info


### PR DESCRIPTION
I noticed the release action failed :-(
https://github.com/brown-ccv/honeycomb/runs/7531318361?check_suite_focus=true#step:12:30

It looks like our CI was using older node version 12 which is incompatible with the electron-forge upgrade.  The error message says electron-forge requires node >= 14.17.5.  I think this is near the end of the node 14 range.  Instead of choosing a minor
version to depend on, I chose the next LTS version, which is 16.

I think 16 is what I tested with locally on my end, too.

Should we bump it up?