### PR TITLE
build: Update chocolatey.config

### DIFF
--- a/chocolatey.config
+++ b/chocolatey.config
@@ -9,5 +9,8 @@
 	<package id="git" />
 	<package id="nodejs-lts" />
 	<package id="vscode" />
+	<package id="pyenv-win" />
+	<package id="visualstudio2022community" />
+	<package id="visualstudio2022-workload-nativedesktop" />
 	<package id="electron" />
-</packages>
+  </packages>


### PR DESCRIPTION
Updates `chcolatey.config` with all prerequisite dependencies for running Honeycomb except Python. Instructions for installing python are merged into the docs [here](https://github.com/brown-ccv/honeycomb-docs/pull/33)