### PR TITLE
fix: add back in the environment file for firebase

### DIFF
--- a/env/.env.firebase
+++ b/env/.env.firebase
@@ -1,0 +1,7 @@
+REACT_APP_FIREBASE="true"
+REACT_APP_apiKey=
+REACT_APP_authDomain=
+REACT_APP_projectId=
+REACT_APP_storageBucket=
+REACT_APP_messagingSenderId=
+REACT_APP_appId=


### PR DESCRIPTION
> Let's re-add the .env.firebase file to source control, and remove that entry from .gitignore. We should do this so that the env var REACT_APP_FIREBASE="true" is set when deploying to firebase. Otherwise, the app doesn't know it's running on firebase and it won't save to firestore.

closes #113 