### PR TITLE
Add VS build tools to chocolatey.config

### DIFF
--- a/chocolatey.config
+++ b/chocolatey.config
@@ -11,6 +11,7 @@
 	<package id="vscode" />
 	<package id="pyenv-win" />
 	<package id="visualstudio2022community" />
-	<package id="visualstudio2022-workload-nativedesktop" />
+	<package id="visualstudio2022buildtools" />
+	<package id="visualcpp-build-tools " />
 	<package id="electron" />
   </packages>


### PR DESCRIPTION
It seems the issue people have been having in slack is because Visual Studio needs to install the c++build tools, not just the workload. I updated the choco file to do so