### PR TITLE
ref: Use function syntax, not arrows

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -22,11 +22,8 @@ let VIDEO = false;
 // Override product ID if environment variable set
 const activeProductId = process.env.EVENT_MARKER_PRODUCT_ID || productId;
 const activeComName = process.env.EVENT_MARKER_COM_NAME || comName;
-if (activeProductId) {
-  log.info('Active product ID', activeProductId);
-} else {
-  log.info('COM Name', activeComName);
-}
+if (activeProductId) log.info('Active product ID', activeProductId);
+else log.info('COM Name', activeComName);
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
@@ -82,7 +79,7 @@ let triggerPort;
 let portAvailable;
 let SKIP_SENDING_DEV = false;
 
-const setUpPort = async () => {
+async function setUpPort() {
   let p;
   if (activeProductId) {
     p = await getPort(vendorId, activeProductId);
@@ -121,9 +118,9 @@ const setUpPort = async () => {
     triggerPort = false;
     portAvailable = false;
   }
-};
+}
 
-const handleEventSend = (code) => {
+function handleEventSend(code) {
   if (!portAvailable && !SKIP_SENDING_DEV) {
     const message = 'Event Marker not connected';
     log.warn(message);
@@ -155,7 +152,7 @@ const handleEventSend = (code) => {
   } else if (!SKIP_SENDING_DEV) {
     sendToPort(triggerPort, code);
   }
-};
+}
 
 // Update env variables with buildtime values from frontend
 ipc.on('updateEnvironmentVariables', (event, args) => {
@@ -183,6 +180,7 @@ ipc.on('trigger', (event, args) => {
 // it is also incrementally saved to the user's app data folder (logged to console)
 
 // INCREMENTAL FILE SAVING
+// TODO: These should be ALL_CAPS
 let stream = false;
 let fileCreated = false;
 let preSavePath = '';
@@ -192,26 +190,28 @@ let studyID = '';
 const images = [];
 let startTrial = -1;
 const today = new Date();
+// Read version file (git sha and branch)
+const git = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'config/version.json')));
 
 /**
  * Abstracts constructing the filepath for saving data for this participant and study.
  * @returns {string} The filepath.
  */
-const getSavePath = (participantID, studyID) => {
+function getSavePath(participantID, studyID) {
   if (participantID !== '' && studyID !== '') {
     const desktop = app.getPath('desktop');
     const name = app.getName();
     const date = today.toISOString().slice(0, 10);
     return path.join(desktop, studyID, participantID, date, name);
   }
-};
+}
 
-const getFullPath = (fileName) => {
-  return path.join(savePath, fileName);
-};
-
-// Read version file (git sha and branch)
-const git = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'config/version.json')));
+/**
+ * Returns the complete path to a file
+ * @param fileName the name of the file to be saved
+ * @returns string
+ */
+const getFullPath = (fileName) => path.join(savePath, fileName);
 
 // Get Participant Id and Study Id from environment
 ipc.on('syncCredentials', (event) => {

--- a/public/electron.js
+++ b/public/electron.js
@@ -211,7 +211,9 @@ function getSavePath(participantID, studyID) {
  * @param fileName the name of the file to be saved
  * @returns string
  */
-const getFullPath = (fileName) => path.join(savePath, fileName);
+function getFullPath(fileName) {
+  return path.join(savePath, fileName);
+}
 
 // Get Participant Id and Study Id from environment
 ipc.on('syncCredentials', (event) => {

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -125,7 +125,9 @@ function App() {
   /** EXPERIMENT FINISH FUNCTIONS */
 
   // Save the experiment data on the desktop
-  const defaultFinishFunction = (data) => data.localSave('csv', 'neuro-task.csv');
+  function defaultFinishFunction(data) {
+    data.localSave('csv', 'neuro-task.csv');
+  }
 
   // Execute the 'end' callback function (see public/electron.js)
   function desktopFinishFunction() {

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -96,21 +96,31 @@ function App() {
   // More information about the arrow function syntax can be found here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions
 
   // Default to valid
-  const defaultValidation = async () => true;
+  async function defaultValidation() {
+    return true;
+  }
   // Validate participant/study against Firestore rules
-  const firebaseValidation = (studyID, participantID) =>
-    validateParticipant(studyID, participantID);
+  function firebaseValidation(studyID, participantID) {
+    return validateParticipant(studyID, participantID);
+  }
 
   /** DATA WRITE FUNCTIONS */
 
+  // TODO: Have an object of functions, accessed by the config variable
   // Do nothing
-  const defaultFunction = () => {};
+  function defaultFunction() {}
   // Add trial data to Firestore
-  const firebaseUpdateFunction = (data) => addToFirebase(data);
-
+  function firebaseUpdateFunction(data) {
+    addToFirebase(data);
+  }
   // Execute the 'data' callback function (see public/electron.js)
-  const desktopUpdateFunction = (data) => ipcRenderer.send('data', data);
-  const psiturkUpdateFunction = (data) => psiturk.recordTrialData(data);
+  function desktopUpdateFunction(data) {
+    ipcRenderer.send('data', data);
+  }
+  // Add trial data to psiturk
+  function psiturkUpdateFunction(data) {
+    psiturk.recordTrialData(data);
+  }
 
   /** EXPERIMENT FINISH FUNCTIONS */
 
@@ -118,8 +128,10 @@ function App() {
   const defaultFinishFunction = (data) => data.localSave('csv', 'neuro-task.csv');
 
   // Execute the 'end' callback function (see public/electron.js)
-  const desktopFinishFunction = () => ipcRenderer.send('end', 'true');
-  const psiturkFinishFunction = () => {
+  function desktopFinishFunction() {
+    ipcRenderer.send('end', 'true');
+  }
+  function psiturkFinishFunction() {
     const completePsiturk = async () => {
       psiturk.saveData({
         success: () => psiturk.completeHIT(),
@@ -127,7 +139,7 @@ function App() {
       });
     };
     completePsiturk();
-  };
+  }
 
   // Update the study/participant data when they log in
   const handleLogin = useCallback((studyID, participantID) => {

--- a/src/components/JsPsychExperiment.jsx
+++ b/src/components/JsPsychExperiment.jsx
@@ -58,13 +58,13 @@ function JsPsychExperiment({
   // Set up event and lifecycle callbacks to start and stop jspsych.
   // Inspiration from jspsych-react: https://github.com/makebrainwaves/jspsych-react/blob/master/src/index.js
   // These useEffect callbacks are similar to componentDidMount / componentWillUnmount.
-  const handleKeyEvent = (e) => {
+  function handleKeyEvent(e) {
     if (e.redispatched) return;
 
     const newEvent = new e.constructor(e.type, e);
     newEvent.redispatched = true;
     experimentDivRef.current.dispatchEvent(newEvent);
-  };
+  }
 
   useEffect(() => {
     // TODO: useLayoutEffect callbacks might be even more similar.

--- a/src/config/main.js
+++ b/src/config/main.js
@@ -1,6 +1,6 @@
 // config/main.js
 // This is the main configuration file where universal and default settings should be placed.
-// These settings can then be imported anywhere in the app as they are exported at the botom of the file.
+// These settings can then be imported anywhere in the app as they are exported at the bottom of the file.
 
 import { initJsPsych } from 'jspsych';
 import _ from 'lodash';
@@ -13,12 +13,13 @@ import packageInfo from '../../package.json';
 const taskName = packageInfo.name;
 const taskVersion = packageInfo.version;
 
-// As of jspsych 7, we instantiate jsPsych where needed insead of importing it globally.
+// As of jspsych 7, we instantiate jsPsych where needed instead of importing it globally.
 // The instance here gives access to utils in jsPsych.turk, for awareness of the mturk environment, if any.
 // The actual task and related utils will use a different instance of jsPsych created after login.
 const jsPsych = initJsPsych();
 
 // mapping of letters to key codes
+// TODO: ALL_CAPS
 const keys = {
   A: 65,
   B: 66,
@@ -29,6 +30,7 @@ const keys = {
 };
 
 // audio codes
+// TODO: ALL_CAPS
 const audioCodes = {
   frequency: 100 * (eventCodes.open_task - 9),
   type: 'sine',
@@ -37,31 +39,35 @@ const audioCodes = {
 // is this mechanical turk?
 const turkInfo = jsPsych.turk.turkInfo();
 const turkUniqueId = `${turkInfo.workerId}:${turkInfo.assignmentId}`;
-const USE_MTURK = !turkInfo.outsideTurk;
-const USE_PROLIFIC = (getProlificId() && !USE_MTURK) || false;
-let USE_ELECTRON = true;
-const USE_FIREBASE = process.env.REACT_APP_FIREBASE === 'true';
 
+// Whether or not we're in an electron instance
+let USE_ELECTRON = true;
 try {
   window.require('electron');
 } catch (error) {
   USE_ELECTRON = false;
 }
+// Whether or not we're using Mechanical Turk
+const USE_MTURK = !turkInfo.outsideTurk;
+// Whether or not we're using Prolific
+const USE_PROLIFIC = (getProlificId() && !USE_MTURK) || false;
+// Whether or not we're using Firebase
+const USE_FIREBASE = process.env.REACT_APP_FIREBASE === 'true';
 
-// whether or not to ask the participant to adjust the volume
-const USE_VOLUME = process.env.REACT_APP_VOLUME === 'true';
-// these variables depend on USE_ELECTRON
-// whether or not to enable video
-const USE_CAMERA = process.env.REACT_APP_VIDEO === 'true' && USE_ELECTRON;
-// whether or not the EEG/event marker is available
+// Whether or not the EEG/event marker is available
 const USE_EEG = process.env.REACT_APP_USE_EEG === 'true' && USE_ELECTRON;
-// whether or not the photodiode is in use
+// Whether or not the photodiode is in use
 const USE_PHOTODIODE = process.env.REACT_APP_USE_PHOTODIODE === 'true' && USE_ELECTRON;
+// Whether or not to enable the volume trial
+const USE_VOLUME = process.env.REACT_APP_VOLUME === 'true';
+// Whether or not to enable video
+const USE_CAMERA = process.env.REACT_APP_VIDEO === 'true' && USE_ELECTRON;
 
-// get language file
+// TODO: Have this be a function? Use i18n?
+// Get language file
 const lang = require('../language/en_us.json');
 if (!USE_ELECTRON) {
-  // if this is mturk, merge in the mturk specific language
+  // If this is mturk, merge in the mturk specific language
   const mlang = require('../language/en_us.mturk.json');
   _.merge(lang, mlang);
 }

--- a/src/config/trigger.js
+++ b/src/config/trigger.js
@@ -1,4 +1,5 @@
 // NOTE - these event codes must match what is in public/config/trigger.js
+// TODO: Import these from public/config/trigger.js
 const eventCodes = {
   fixation: 1,
   evidence: 5,
@@ -7,7 +8,8 @@ const eventCodes = {
   open_task: 18,
 };
 
-// this is module.exports isntead of just exports as it is also imported into the electron app
+// this is module.exports instead of just exports as it is also imported into the electron app
+// TODO: Let electron use ES7 syntax
 module.exports = {
   eventCodes,
 };

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -21,13 +21,15 @@ if (window.location.hostname === 'localhost') db.useEmulator('localhost', 8080);
 
 // Get a reference to the Firebase document at
 // "/participant_responses/{studyID}/participants/{participantID}"
-const getParticipantRef = (studyID, participantID) =>
-  db.doc(`participant_responses/${studyID}/participants/${participantID}`);
+function getParticipantRef(studyID, participantID) {
+  return db.doc(`participant_responses/${studyID}/participants/${participantID}`);
+}
 
 // Get a reference to the Firebase document at
 // "/participant_responses/{studyID}/participants/{participantID}/data/{startDate}"
-const getExperimentRef = (studyID, participantID, startDate) =>
-  db.doc(`${getParticipantRef(studyID, participantID).path}/data/${startDate}`);
+function getExperimentRef(studyID, participantID, startDate) {
+  return db.doc(`${getParticipantRef(studyID, participantID).path}/data/${startDate}`);
+}
 
 /**
  * Validate the given studyID & participantID combo

--- a/src/lib/markup/earnings.js
+++ b/src/lib/markup/earnings.js
@@ -1,10 +1,10 @@
 import { formatDollars } from '../utils';
 
-const earningsDisplay = (earnings) => {
+function earningsDisplay(earnings) {
   const bclass = earnings >= 0 ? 'success' : 'danger';
   return `<div class='center_container'>
     <h1 class='text-${bclass}'>${formatDollars(earnings)}</h1>
     </div>`;
-};
+}
 
 export { earningsDisplay };

--- a/src/lib/markup/earnings.js
+++ b/src/lib/markup/earnings.js
@@ -1,5 +1,6 @@
 import { formatDollars } from '../utils';
 
+// TODO: Have a markup.js file, consolidate these other files
 function earningsDisplay(earnings) {
   const bclass = earnings >= 0 ? 'success' : 'danger';
   return `<div class='center_container'>

--- a/src/lib/markup/eventMarkerMessage.js
+++ b/src/lib/markup/eventMarkerMessage.js
@@ -1,7 +1,8 @@
 import { lang } from '../../config/main';
 
-const eventMarkerMessage = async () => {
+// TODO: Have a markup.js file, consolidate these other files
+async function eventMarkerMessage() {
   return `<span style="color: green;">${lang.eventMarker.found}</span>`;
-};
+}
 
 export default eventMarkerMessage;

--- a/src/lib/markup/fixation.js
+++ b/src/lib/markup/fixation.js
@@ -1,1 +1,3 @@
+// TODO: Make a function to match other files
+// TODO: Have a markup.js file, consolidate these other files
 export const fixationHTML = '<div class="center_container"><div id="fixation-dot"> </div></div>';

--- a/src/lib/markup/photodiode.js
+++ b/src/lib/markup/photodiode.js
@@ -10,16 +10,16 @@ if (config.USE_ELECTRON) {
 }
 
 // Relies on styling in index.css, generate PD spot
-const photodiodeGhostBox = () => {
+function photodiodeGhostBox() {
   const class_ = config.USE_PHOTODIODE ? 'visible' : 'invisible';
 
   const markup = `<div class="photodiode-box ${class_}" id="photodiode-box">
       <span id="photodiode-spot" class="photodiode-spot"></span>
     </div>`;
   return markup;
-};
+}
 
-const pdSpotEncode = (taskCode) => {
+function pdSpotEncode(taskCode) {
   function pulseFor(ms, callback) {
     $('.photodiode-spot').css({ 'background-color': 'black' });
     setTimeout(() => {
@@ -45,6 +45,6 @@ const pdSpotEncode = (taskCode) => {
     repeatPulseFor(blinkTime, numBlinks);
     if (ipcRenderer) ipcRenderer.send('trigger', taskCode);
   }
-};
+}
 
 export { photodiodeGhostBox, pdSpotEncode };

--- a/src/lib/markup/stimuli.js
+++ b/src/lib/markup/stimuli.js
@@ -1,6 +1,7 @@
-const baseStimulus = (element, prompt = false, centered = false) => {
+// TODO: This should be a "component"? Some constant?
+function baseStimulus(element, prompt = false, centered = false) {
   const class_ = centered ? 'center_container' : prompt ? 'main-prompt' : 'main';
   return `<div class=${class_}>${element}</div>`;
-};
+}
 
 export { baseStimulus };

--- a/src/lib/markup/stimuli.js
+++ b/src/lib/markup/stimuli.js
@@ -1,4 +1,5 @@
 // TODO: This should be a "component"? Some constant?
+// TODO: Have a markup.js file, consolidate these other files
 function baseStimulus(element, prompt = false, centered = false) {
   const class_ = centered ? 'center_container' : prompt ? 'main-prompt' : 'main';
   return `<div class=${class_}>${element}</div>`;

--- a/src/lib/taskUtils.js
+++ b/src/lib/taskUtils.js
@@ -1,15 +1,15 @@
 // utilities specific to this app/task
-
+// TODO: Only one utils file
 import _ from 'lodash';
 
 // initialize starting conditions for each trial within a block
-const generateStartingOpts = (blockSettings) => {
+function generateStartingOpts(blockSettings) {
   const startingOptions = blockSettings.conditions.map((c) => {
     // Repeat each starting condition the same number of times
     return _.range(blockSettings.repeats_per_condition).map(() => c);
   });
 
   return _.shuffle(_.flatten(startingOptions));
-};
+}
 
 export { generateStartingOpts };

--- a/src/lib/taskUtils.js
+++ b/src/lib/taskUtils.js
@@ -1,4 +1,4 @@
-// utilities specific to this app/task
+// Utilities specific to this app/task
 // TODO: Only one utils file
 import _ from 'lodash';
 

--- a/src/lib/taskUtils.js
+++ b/src/lib/taskUtils.js
@@ -3,7 +3,7 @@
 import _ from 'lodash';
 
 // initialize starting conditions for each trial within a block
-function generateStartingOpts(blockSettings) {
+function generateStartingOptions(blockSettings) {
   const startingOptions = blockSettings.conditions.map((c) => {
     // Repeat each starting condition the same number of times
     return _.range(blockSettings.repeats_per_condition).map(() => c);
@@ -12,4 +12,4 @@ function generateStartingOpts(blockSettings) {
   return _.shuffle(_.flatten(startingOptions));
 }
 
-export { generateStartingOpts };
+export { generateStartingOptions };

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,44 +1,51 @@
 import requireContext from 'require-context.macro';
 
-const sleep = (ms) => {
+function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
-};
+}
 
 // add a random number between 0 and offset to the base number
-const jitter = (base, offset) => base + Math.floor(Math.random() * Math.floor(offset));
+function jitter(base, offset) {
+  return base + Math.floor(Math.random() * Math.floor(offset));
+}
 
 // add a random number between 0 and 50 to the base number
-const jitter50 = (base) => jitter(base, 50);
+function jitter50(base) {
+  return jitter(base, 50);
+}
 
 // flip a coin
-const randomTrue = () => Math.random() > 0.5;
+function randomTrue() {
+  return Math.random() > 0.5;
+}
 
 // deeply copy an object
-const deepCopy = (obj) => JSON.parse(JSON.stringify(obj));
+function deepCopy(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}
 
 // format a number as a dollar amount
-const formatDollars = (amount) => '$' + parseFloat(amount).toFixed(2);
+function formatDollars(amount) {
+  return '$' + parseFloat(amount).toFixed(2);
+}
 
 // create a pre-trial wait period
-const generateWaitSet = (trial, waitTime) => {
+function generateWaitSet(trial, waitTime) {
   const waitTrial = Object.assign({}, trial);
   waitTrial.trial_duration = waitTime;
   waitTrial.response_ends_trial = false;
   waitTrial.prompt = '-';
 
   return [waitTrial, trial];
-};
+}
 
 // As of jspsych 7, we instantiate jsPsych where needed insead of importing it globally.
 // The jsPsych instance passed in here should be the same one used for the running task.
-const startKeypressListener = (jsPsych) => {
-  const keypressResponse = (info) => {
-    const data = {
-      key_press: info.key,
-    };
-
+function startKeypressListener(jsPsych) {
+  function keypressResponse(info) {
+    const data = { key_press: info.key };
     jsPsych.finishTrial(data);
-  };
+  }
 
   const keyboardListener = jsPsych.pluginAPI.getKeyboardResponse({
     callback_function: keypressResponse,
@@ -47,7 +54,7 @@ const startKeypressListener = (jsPsych) => {
   });
 
   return keyboardListener;
-};
+}
 
 // Discover and import images in src/assets/images.
 // This produces an object that maps friendly image file names to obscure webpack path names.
@@ -56,33 +63,30 @@ const startKeypressListener = (jsPsych) => {
 //     image1.png: '/static/media/image1.5dca7a2a50fb8b633fd5.png',
 //     image2.png: '/static/media/image2.5dca7a2a50fb8b633fd5.png'
 //   }
-const importAll = (r) => {
-  const importImageByName = (allImages, imageName) => {
+function importAll(r) {
+  function importImageByName(allImages, imageName) {
     const friendlyName = imageName.replace('./', '');
     return { ...allImages, [friendlyName]: r(imageName) };
-  };
+  }
   return r.keys().reduce(importImageByName, {});
-};
-
+}
+// TODO: move to constants file
 const images = importAll(requireContext('../assets/images', false, /\.(png|jpe?g|svg)$/));
 
-const getQueryVariable = (variable) => {
+function getQueryVariable(variable) {
   const query = window.location.search.substring(1);
   const vars = query.split('&');
   for (let i = 0; i < vars.length; i++) {
     const pair = vars[i].split('=');
-    if (decodeURIComponent(pair[0]) === variable) {
-      return decodeURIComponent(pair[1]);
-    }
+    if (decodeURIComponent(pair[0]) === variable) return decodeURIComponent(pair[1]);
   }
-};
+}
 
-const getProlificId = () => {
-  const prolificId = getQueryVariable('PROLIFIC_PID');
-  return prolificId;
-};
+function getProlificId() {
+  return getQueryVariable('PROLIFIC_PID');
+}
 
-const beep = (audioCodes) => {
+function beep(audioCodes) {
   const context = new AudioContext(); // eslint-disable-line no-undef
   const o = context.createOscillator();
   const g = context.createGain();
@@ -93,7 +97,7 @@ const beep = (audioCodes) => {
   g.connect(context.destination);
   o.start();
   o.stop(context.currentTime + 0.4);
-};
+}
 
 export {
   sleep,

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,35 +1,60 @@
 import requireContext from 'require-context.macro';
 
+/**
+ * Delay program execution
+ * @param {number} ms Time to sleep for in milliseconds
+ */
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-// add a random number between 0 and offset to the base number
+/**
+ * Add a random number between 0 and offset to the base number
+ * @param {number} base Starting number
+ * @param {number} offset Maximum jitter offset
+ * @returns
+ */
 function jitter(base, offset) {
   return base + Math.floor(Math.random() * Math.floor(offset));
 }
 
-// add a random number between 0 and 50 to the base number
+/**
+ * Add a random number between 0 and 50 to the base number
+ * @param {number} base Starting number
+ */
 function jitter50(base) {
   return jitter(base, 50);
 }
 
-// flip a coin
+/**
+ * Flips a coin
+ */
 function randomTrue() {
   return Math.random() > 0.5;
 }
 
-// deeply copy an object
+/**
+ * Copies a deeply nested object
+ * @param {Object} obj Object to be copied
+ */
 function deepCopy(obj) {
   return JSON.parse(JSON.stringify(obj));
 }
 
-// format a number as a dollar amount
+/**
+ * Format a number as a US dollar amount
+ * @param {number} amount Dollar amount
+ */
 function formatDollars(amount) {
   return '$' + parseFloat(amount).toFixed(2);
 }
 
-// create a pre-trial wait period
+/**
+ * Adds a wait period before a trial begins
+ * @param {*} trial The trial to add a wait period to
+ * @param {*} waitTime The amount of time to wait by
+ */
+// TODO: This should be a trial not a utility? It's adding a separate trial in and of itself
 function generateWaitSet(trial, waitTime) {
   const waitTrial = Object.assign({}, trial);
   waitTrial.trial_duration = waitTime;
@@ -39,8 +64,10 @@ function generateWaitSet(trial, waitTime) {
   return [waitTrial, trial];
 }
 
-// As of jspsych 7, we instantiate jsPsych where needed insead of importing it globally.
-// The jsPsych instance passed in here should be the same one used for the running task.
+/**
+ * Starts the JsPsych keyboard response listener
+ * @param  jsPsych The jsPsych instance running the task.
+ */
 function startKeypressListener(jsPsych) {
   function keypressResponse(info) {
     const data = { key_press: info.key };
@@ -56,13 +83,17 @@ function startKeypressListener(jsPsych) {
   return keyboardListener;
 }
 
-// Discover and import images in src/assets/images.
-// This produces an object that maps friendly image file names to obscure webpack path names.
-// For example:
-//   {
-//     image1.png: '/static/media/image1.5dca7a2a50fb8b633fd5.png',
-//     image2.png: '/static/media/image2.5dca7a2a50fb8b633fd5.png'
-//   }
+/**
+ * Discover and import images in src/assets/images.
+ * This produces an object that maps friendly image file names to obscure webpack path names.
+ *  For example:
+ *    {
+ *      image1.png: '/static/media/image1.5dca7a2a50fb8b633fd5.png',
+ *      image2.png: '/static/media/image2.5dca7a2a50fb8b633fd5.png'
+ *    }
+ * @param {Object} r
+ * @returns
+ */
 function importAll(r) {
   function importImageByName(allImages, imageName) {
     const friendlyName = imageName.replace('./', '');
@@ -70,9 +101,14 @@ function importAll(r) {
   }
   return r.keys().reduce(importImageByName, {});
 }
-// TODO: move to constants file
+// TODO: move to constants file, ALL_CAPS
 const images = importAll(requireContext('../assets/images', false, /\.(png|jpe?g|svg)$/));
 
+/**
+ * Get a query parameter out of the window's URL
+ * @param {*} variable The key to parse
+ */
+// TODO: Can this just use URLSearchParams?
 function getQueryVariable(variable) {
   const query = window.location.search.substring(1);
   const vars = query.split('&');
@@ -82,12 +118,19 @@ function getQueryVariable(variable) {
   }
 }
 
+/**
+ * Gets the getProlificId from the query string
+ */
 function getProlificId() {
   return getQueryVariable('PROLIFIC_PID');
 }
 
+/**
+ * Emits an audible beep
+ * @param {*} audioCodes The type/frequency of the beep
+ */
 function beep(audioCodes) {
-  const context = new AudioContext(); // eslint-disable-line no-undef
+  const context = new AudioContext();
   const o = context.createOscillator();
   const g = context.createGain();
   o.type = audioCodes.type;

--- a/src/timelines/main.js
+++ b/src/timelines/main.js
@@ -22,10 +22,11 @@ const jsPsychOptions = {
 // Add your jsPsych timeline here.
 // Honeycomb will call this function for us after the subject logs in, and run the resulting timeline.
 // The instance of jsPsych passed in will include jsPsychOptions above, plus other options needed by Honeycomb.
-const buildTimeline = (jsPsych) =>
-  config.USE_MTURK ? mturkTimeline : buildPrimaryTimeline(jsPsych);
+function buildTimeline(jsPsych) {
+  return config.USE_MTURK ? mturkTimeline : buildPrimaryTimeline(jsPsych);
+}
 
-const buildPrimaryTimeline = (jsPsych) => {
+function buildPrimaryTimeline(jsPsych) {
   const primaryTimeline = [
     preamble,
     ageCheck,
@@ -52,7 +53,7 @@ const buildPrimaryTimeline = (jsPsych) => {
   );
 
   return primaryTimeline;
-};
+}
 
 const mturkTimeline = [
   preamble,

--- a/src/timelines/taskBlock.js
+++ b/src/timelines/taskBlock.js
@@ -1,11 +1,11 @@
 import htmlKeyboardResponse from '@jspsych/plugin-html-keyboard-response';
 import taskTrial from './taskTrial';
-import { generateStartingOpts } from '../lib/taskUtils';
+import { generateStartingOptions } from '../lib/taskUtils';
 
 // TODO: Rename as function?
 function taskBlock(blockSettings) {
   // initialize block
-  const startingOpts = generateStartingOpts(blockSettings);
+  const startingOpts = generateStartingOptions(blockSettings);
 
   const blockDetails = {
     block_earnings: 0.0,

--- a/src/timelines/taskBlock.js
+++ b/src/timelines/taskBlock.js
@@ -2,7 +2,8 @@ import htmlKeyboardResponse from '@jspsych/plugin-html-keyboard-response';
 import taskTrial from './taskTrial';
 import { generateStartingOpts } from '../lib/taskUtils';
 
-const taskBlock = (blockSettings) => {
+// TODO: Rename as function?
+function taskBlock(blockSettings) {
   // initialize block
   const startingOpts = generateStartingOpts(blockSettings);
 
@@ -32,6 +33,6 @@ const taskBlock = (blockSettings) => {
     type: htmlKeyboardResponse,
     timeline,
   };
-};
+}
 
 export default taskBlock;

--- a/src/timelines/taskTrial.js
+++ b/src/timelines/taskTrial.js
@@ -4,22 +4,18 @@ import { config, eventCodes } from '../config/main';
 
 import { earningsDisplay } from '../lib/markup/earnings';
 
-const taskTrial = (blockSettings, blockDetails, condition) => {
+function taskTrial(blockSettings, blockDetails, condition) {
   // timeline
   const timeline = [
     // fixation
-    fixation(config, {
-      duration: 650,
-    }),
+    fixation(config, { duration: 650 }),
     // show condition
     showMessage(config, {
       message: condition,
       onstart: true,
       taskCode: eventCodes.evidence,
     }),
-    fixation(config, {
-      duration: 650,
-    }),
+    fixation(config, { duration: 650 }),
     // end the trial
     showMessage(config, {
       stimulus: earningsDisplay(Math.random()),
@@ -31,6 +27,6 @@ const taskTrial = (blockSettings, blockDetails, condition) => {
     type: htmlKeyboardResponse,
     timeline,
   };
-};
+}
 
 export default taskTrial;

--- a/src/trials/adjustVolume.js
+++ b/src/trials/adjustVolume.js
@@ -2,7 +2,8 @@ import htmlKeyboardResponse from '@jspsych/plugin-html-keyboard-response';
 import { lang } from '../config/main';
 import { baseStimulus } from '../lib/markup/stimuli';
 
-const adjustVolume = () => {
+// TODO: This is an example task
+function adjustVolume() {
   const stimulus = baseStimulus(
     `
     <div class='instructions'>
@@ -18,6 +19,6 @@ const adjustVolume = () => {
     prompt: lang.prompt.continue.press,
     response_ends_trial: true,
   };
-};
+}
 
 export default adjustVolume;

--- a/src/trials/camera.js
+++ b/src/trials/camera.js
@@ -25,7 +25,7 @@ function saveBlob(blob, media, participantID) {
 
 // As of jspsych 7, we instantiate jsPsych where needed insead of importing it globally.
 // The jsPsych instance passed in here should be the same one used for the running task.
-const cameraStart = (jsPsych) => {
+function cameraStart(jsPsych) {
   document.title = taskName;
   const markup = `
   <div class="d-flex flex-column align-items-center">
@@ -87,9 +87,7 @@ const cameraStart = (jsPsych) => {
                   },
                 },
               })
-              .then((stream) => {
-                handleEvents(stream, 'screenCapture');
-              })
+              .then((stream) => handleEvents(stream, 'screenCapture'))
               .catch((error) => console.log(error));
           }
         }
@@ -108,9 +106,9 @@ const cameraStart = (jsPsych) => {
       }
     },
   };
-};
+}
 
-const cameraEnd = (duration) => {
+function cameraEnd(duration) {
   const stimulus = baseStimulus(`<h1>${lang.task.recording_end}</h1>`, true) + photodiodeGhostBox();
 
   return {
@@ -129,6 +127,6 @@ const cameraEnd = (duration) => {
       }
     },
   };
-};
+}
 
 export { cameraStart, cameraEnd };

--- a/src/trials/camera.js
+++ b/src/trials/camera.js
@@ -4,27 +4,16 @@ import { lang, taskName, config } from '../config/main';
 import { photodiodeGhostBox } from '../lib/markup/photodiode';
 import { baseStimulus } from '../lib/markup/stimuli';
 
+// Get the ipcRender if running in an  electron window
+// TODO: Is it okay for this to start undefined?
+// TODO: Add warning to trial if not running in electron?
 let ipcRenderer = false;
-if (config.USE_ELECTRON) {
-  const electron = window.require('electron');
-  ipcRenderer = electron.ipcRenderer;
-}
+if (config.USE_ELECTRON) ipcRenderer = window.require('electron').ipcRenderer;
 
-function saveBlob(blob, media, participantID) {
-  const reader = new FileReader(); // eslint-disable-line no-undef
-  const fileName = `pid_${participantID}_${media}_${Date.now()}.webm`;
-  reader.onload = function () {
-    if (reader.readyState === 2) {
-      const buffer = Buffer.from(reader.result); // eslint-disable-line no-undef
-      ipcRenderer.send('save_video', fileName, buffer);
-      console.log(`Saving ${JSON.stringify({ fileName, size: blob.size })}`);
-    }
-  };
-  reader.readAsArrayBuffer(blob);
-}
-
-// As of jspsych 7, we instantiate jsPsych where needed insead of importing it globally.
-// The jsPsych instance passed in here should be the same one used for the running task.
+/**
+ * Experiment trial for starting a participant's camera feed
+ * @param jsPsych The currently running JsPsych instance
+ */
 function cameraStart(jsPsych) {
   document.title = taskName;
   const markup = `
@@ -65,7 +54,16 @@ function cameraStart(jsPsych) {
 
         window[recorder].addEventListener('stop', function () {
           const blob = new Blob(recordedChunks); // eslint-disable-line no-undef
-          saveBlob(blob, recorder, participantID);
+          const reader = new FileReader(); // eslint-disable-line no-undef
+          const fileName = `pid_${participantID}_${recorder}_${Date.now()}.webm`;
+          reader.onload = function () {
+            if (reader.readyState === 2) {
+              const buffer = Buffer.from(reader.result); // eslint-disable-line no-undef
+              ipcRenderer.send('save_video', fileName, buffer);
+              console.log(`Saving ${JSON.stringify({ fileName, size: blob.size })}`);
+            }
+          };
+          reader.readAsArrayBuffer(blob);
         });
       };
 
@@ -74,7 +72,6 @@ function cameraStart(jsPsych) {
         .then((stream) => handleEvents(stream, 'cameraCapture'));
 
       const { desktopCapturer } = window.require('electron');
-
       desktopCapturer.getSources({ types: ['window'] }).then(async (sources) => {
         for (const source of sources) {
           if (source.name === taskName) {
@@ -108,6 +105,10 @@ function cameraStart(jsPsych) {
   };
 }
 
+/**
+ * Experiment trial for ending a participant's camera feed
+ * @param duration How long for the trial to run for
+ */
 function cameraEnd(duration) {
   const stimulus = baseStimulus(`<h1>${lang.task.recording_end}</h1>`, true) + photodiodeGhostBox();
 

--- a/src/trials/holdUpMarker.js
+++ b/src/trials/holdUpMarker.js
@@ -4,7 +4,7 @@ import { photodiodeGhostBox } from '../lib/markup/photodiode';
 import { baseStimulus } from '../lib/markup/stimuli';
 import eventMarkerMessage from '../lib/markup/eventMarkerMessage';
 
-const holdUpMarker = () => {
+function holdUpMarker() {
   const stimulus = baseStimulus("<div><h2 id='usb-alert'></h2></div>", true) + photodiodeGhostBox();
 
   return {
@@ -12,11 +12,10 @@ const holdUpMarker = () => {
     stimulus,
     prompt: [`<br><h3>${lang.prompt.focus}</h3>`],
     choices: [lang.prompt.continue.button],
-    on_load: () =>
-      eventMarkerMessage().then((s) => {
-        document.getElementById('usb-alert').innerHTML = s;
-      }),
+    on_load: () => {
+      eventMarkerMessage().then((s) => (document.getElementById('usb-alert').innerHTML = s));
+    },
   };
-};
+}
 
 export default holdUpMarker;

--- a/src/trials/quizTrials.js
+++ b/src/trials/quizTrials.js
@@ -3,6 +3,9 @@ import surveyMultiselect from '@jspsych/plugin-survey-multi-select';
 import { lang, config } from '../config/main';
 import { survey, slider, multiSurvey, showMessage } from '@brown-ccv/behavioral-task-trials';
 
+// TODO: Split each question into its own function?
+// TODO: Add trial for loading a prolific questionnaire?
+
 // Age Check
 const ask = lang.quiz.ask.age;
 const res = lang.quiz.answer.age;

--- a/src/trials/startCode.js
+++ b/src/trials/startCode.js
@@ -4,7 +4,7 @@ import { photodiodeGhostBox, pdSpotEncode } from '../lib/markup/photodiode';
 import { baseStimulus } from '../lib/markup/stimuli';
 import { beep } from '../lib/utils';
 
-const startCode = () => {
+function startCode() {
   const stimulus = baseStimulus(`<h1>${lang.prompt.setting_up}</h1>`, true) + photodiodeGhostBox();
 
   return {
@@ -16,6 +16,6 @@ const startCode = () => {
       beep(audioCodes);
     },
   };
-};
+}
 
 export default startCode;

--- a/src/trials/welcome.js
+++ b/src/trials/welcome.js
@@ -3,7 +3,8 @@ import { lang } from '../config/main';
 import { photodiodeGhostBox } from '../lib/markup/photodiode';
 import { baseStimulus } from '../lib/markup/stimuli';
 
-const pleaseBiggen = () => {
+// TODO: Pull into its own file
+function pleaseBiggen() {
   const stimulus =
     baseStimulus(`<h1>${lang.welcome.large_window}</h1>`, true) + photodiodeGhostBox();
 
@@ -13,9 +14,9 @@ const pleaseBiggen = () => {
     prompt: lang.prompt.continue.press,
     response_ends_trial: true,
   };
-};
+}
 
-const welcomeMessage = () => {
+function welcomeMessage() {
   const stimulus = baseStimulus(`<h1>${lang.welcome.message}</h1>`, true) + photodiodeGhostBox();
 
   return {
@@ -24,7 +25,7 @@ const welcomeMessage = () => {
     prompt: lang.prompt.continue.press,
     response_ends_trial: true,
   };
-};
+}
 
 const welcome = {
   type: htmlKeyboardResponse,


### PR DESCRIPTION
Completes what was started in #182, but ONLY refactors the function stuff, will mess with the `export` declerations in another PR.

- Use function syntax instead of arrows
- Adds documentation to functions
- Generally cleans up comments