### PR TITLE
ref: Refactor countdown trial

### DIFF
--- a/src/JsPsych/timeline.js
+++ b/src/JsPsych/timeline.js
@@ -1,6 +1,7 @@
+// TODO: @ import for language
 import { language } from './language';
 // TODO: @ import for trials
-import { Preamble, createSliderTrial } from './trials/examples';
+import { Preamble, createCountdownTrial, createSliderTrial } from './trials/examples';
 import { AgeCheck } from './trials/examples/survey';
 
 /**
@@ -26,9 +27,14 @@ export const JSPSYCH_OPTIONS = {
 // eslint-disable-next-line
 export function buildTimeline(jsPsych) {
   // Get slider text from the language file and create the trials
-  const sliderMessages = language.quiz.direction.slider;
-  const sliderLeft = createSliderTrial(sliderMessages.left);
-  const sliderRight = createSliderTrial(sliderMessages.right);
+  const sliderLanguage = language.quiz.direction.slider;
+  const sliderLeft = createSliderTrial(sliderLanguage.left);
+  const sliderRight = createSliderTrial(sliderLanguage.right);
+
+  // Get countdown txt from the language fil and create the trials
+  const countdownLanguage = language.countdown;
+  const firstBlockCountdown = createCountdownTrial({ message: countdownLanguage.message1 });
+  const secondBlockCountdown = createCountdownTrial({ message: countdownLanguage.message2 });
 
   // Build the timeline
   const timeline = [
@@ -36,6 +42,9 @@ export function buildTimeline(jsPsych) {
     AgeCheck,
     sliderLeft,
     sliderRight,
+    firstBlockCountdown,
+    secondBlockCountdown,
+
     // countdown({ message: lang.countdown.message1 }),
     // taskBlock(practiceBlock),
     // countdown({ message: lang.countdown.message2 }),

--- a/src/JsPsych/trials/examples/Countdown.js
+++ b/src/JsPsych/trials/examples/Countdown.js
@@ -1,0 +1,36 @@
+import { range } from 'lodash';
+import htmlKeyboardResponse from '@jspsych/plugin-html-keyboard-response';
+
+/**
+ * Builds a countdown transition with the given message and number of seconds.
+ * Counts down from "time" to 0, each step is displayed for "duration" seconds
+ *
+ * @param {number} duration - trial duration in milliseconds. (default: 1000)
+ * @param {string} stimulus - Onscreen stimulus in HTML to be shown in the trial. If the stimulus is not provided, message should be provided as a string. (default: "")
+ * @param {string} message - (optional) message for the countdown. (default: "")
+ * @param {number} time - start number for the countdown. (default: 3)
+ */
+// TODO: Always use <h3>? Pass message and remove stimulus? Default to undefined instead of empty strings?
+// TODO: Can we do this in 1 trial instead of a nested timeline?
+// TODO: This isn't a keyboard response? Just instructions? Definitely don't need user input
+export function createCountdownTrial({
+  duration = 1000, // Default to 1 second per trial
+  stimulus = '', // Default empty stimulus
+  message = '', // Default empty message
+  time = 3, // Default 3...2...1... countdown
+} = {}) {
+  const stimulusOrMessage = message !== '' ? `<h3>${message}</h3>` : stimulus;
+
+  // Countdown from time -> 0
+  const timeline = range(time, 0, -1).map((n) => ({ prompt: `<h1>${n}</h1>` }));
+
+  return {
+    type: htmlKeyboardResponse,
+    stimulus: stimulusOrMessage,
+    trial_duration: duration,
+    response_ends_trial: false,
+    timeline: timeline,
+  };
+}
+
+export const Countdown = createCountdownTrial();

--- a/src/JsPsych/trials/examples/index.js
+++ b/src/JsPsych/trials/examples/index.js
@@ -1,2 +1,3 @@
 export * from './Preamble';
 export * from './Slider';
+export * from './Countdown';


### PR DESCRIPTION
- Adds `Countdown.js` example trial, copies code from [trials repo](https://github.com/brown-ccv/behavioral-task-trials/blob/main/trials/countdown.js)