### PR TITLE
ref: Move `camera.js` into `trials/examples/camera`

### DIFF
--- a/src/JsPsych/timeline.js
+++ b/src/JsPsych/timeline.js
@@ -1,20 +1,9 @@
 // TODO 204: @ import for language
 import { language } from './language';
-// TODO 204: @ import for trials
-import {
-  Preamble,
-  createCountdownTrial,
-  createSliderTrial,
-  AgeCheck,
-  EndExperiment,
-  AdjustVolume,
-  LargeWindow,
-  WelcomeMessage,
-} from './trials/examples';
-import { createHoneycombBlock } from './trials/honeycombBlock';
 
-import { DebriefSurvey, IusSurvey } from './trials/examples/survey';
-import { DemographicsSurvey } from './trials/examples/survey/Demographics';
+// TODO 204: @ import for trials
+import { Preamble, createCountdownTrial, EndExperiment } from './trials/examples';
+import { createHoneycombBlock } from './trials/honeycombBlock';
 
 /**
  * Create your custom JsPsych options here. These settings will applied experiment wide.
@@ -39,9 +28,9 @@ export const JSPSYCH_OPTIONS = {
 // eslint-disable-next-line
 export function buildTimeline(jsPsych) {
   // Get slider text from the language file and create the trials
-  const sliderLanguage = language.quiz.direction.slider;
-  const sliderLeft = createSliderTrial(sliderLanguage.left);
-  const sliderRight = createSliderTrial(sliderLanguage.right);
+  // const sliderLanguage = language.quiz.direction.slider;
+  // const sliderLeft = createSliderTrial(sliderLanguage.left);
+  // const sliderRight = createSliderTrial(sliderLanguage.right);
 
   // Get countdown txt from the language fil and create the trials+
   const countdownLanguage = language.countdown;
@@ -69,19 +58,11 @@ export function buildTimeline(jsPsych) {
   // Build the timeline
   const timeline = [
     Preamble,
-    LargeWindow,
-    WelcomeMessage,
-    // AgeCheck,
-    // sliderLeft,
-    // sliderRight,
-    // honeycombTutorialBlock,
-    // firstBlockCountdown,
-    // honeycombPracticeBlock,
-    // secondBlockCountdown,
-    // honeycombBlock1,
-    // DemographicsSurvey,
-    // IusSurvey,
-    DebriefSurvey, // "Confirm Completion" button
+    honeycombTutorialBlock,
+    firstBlockCountdown,
+    honeycombPracticeBlock,
+    secondBlockCountdown,
+    honeycombBlock1,
     EndExperiment, // Task complete message
   ];
   return timeline;

--- a/src/JsPsych/trials/examples/camera/CameraEnd.js
+++ b/src/JsPsych/trials/examples/camera/CameraEnd.js
@@ -1,0 +1,40 @@
+import htmlKeyboardResponse from '@jspsych/plugin-html-keyboard-response';
+
+// TODO: Move markup to JsPsych?
+import { photodiodeGhostBox } from '../../../../lib/markup/photodiode';
+import { baseStimulus } from '../../../../lib/markup/stimuli';
+
+import { language } from '../../../language';
+
+// TODO: This is a task, how do I pass which config file to use?
+// Hard code for now
+import config from '../../../config/home.json';
+
+/**
+ * Experiment trial for ending a participant's camera feed
+ * @param duration How long for the trial to run for
+ */
+export function createCameraEndTrial(duration) {
+  const stimulus =
+    baseStimulus(`<h1>${language.task.recording_end}</h1>`, true) + photodiodeGhostBox();
+
+  return {
+    type: htmlKeyboardResponse,
+    stimulus,
+    trial_duration: duration,
+    on_load: () => {
+      //   if (config.USE_CAMERA) {
+      if (config.equipment.camera === true) {
+        console.log('finished');
+        try {
+          window.cameraCapture.stop();
+          window.screenCapture.stop();
+        } catch (error) {
+          window.alert('Your video recording was not saved');
+        }
+      }
+    },
+  };
+}
+
+export const CameraEnd = createCameraEndTrial();

--- a/src/JsPsych/trials/examples/camera/CameraStart.js
+++ b/src/JsPsych/trials/examples/camera/CameraStart.js
@@ -1,0 +1,124 @@
+import htmlButtonResponse from '@jspsych/plugin-html-button-response';
+
+// TODO: Move markup to JsPsych?
+import { photodiodeGhostBox } from '../../../../lib/markup/photodiode';
+import { baseStimulus } from '../../../../lib/markup/stimuli';
+
+import { language } from '../../../language';
+import { TASK_NAME } from '../../../constants';
+
+// TODO: This is a task, how do I pass which config file to use?
+// Hard code for now
+import config from '../../../config/home.json';
+import { initJsPsych } from 'jspsych';
+
+// Get the ipcRender if running in an  electron window
+// TODO 192: Is it okay for this to start undefined?
+// TODO 192: Add warning to trial if not running in electron?
+let ipcRenderer = false;
+// TODO: Camera can now be accessed by the browser
+// if (config.USE_ELECTRON) {
+// if (config.equipment.camera === true) {
+//   ipcRenderer = window.require('electron').ipcRenderer;
+// }
+
+// ! This will break, need only a single JsPsych instance for the whole app
+const JSPSYCH = initJsPsych();
+
+/**
+ * Experiment trial for starting a participant's camera feed
+ */
+// TODO: JsPsych now has built in camera initialization
+// TODO: How to pass JsPsych instance into the trials?
+export function createCameraStartTrial() {
+  document.title = TASK_NAME;
+  const markup = `
+  <div class="d-flex flex-column align-items-center">
+  <p>${language.instructions.camera}</p>
+  <video id="camera" width="640" height="480" autoplay></video>
+  </div>
+  `;
+  const stimulus = baseStimulus(markup, true) + photodiodeGhostBox();
+
+  return {
+    type: htmlButtonResponse,
+    stimulus,
+    choices: [language.prompt.continue.button],
+    response_ends_trial: true,
+    on_load: () => {
+      // Grab elements, create settings, etc.
+      // Elements for taking the snapshot
+      const participantID = JSPSYCH.data.get().values()[0].participant_id;
+
+      const camera = document.getElementById('camera');
+
+      const handleEvents = function (stream, recorder) {
+        console.log(stream);
+        if (recorder === 'cameraCapture') {
+          camera.srcObject = stream;
+        }
+
+        const options = { mimeType: 'video/webm' };
+        const recordedChunks = [];
+        window[recorder] = new MediaRecorder(stream, options); // eslint-disable-line no-undef
+
+        window[recorder].addEventListener('dataavailable', function (e) {
+          if (e.data.size > 0) {
+            recordedChunks.push(e.data);
+          }
+        });
+
+        window[recorder].addEventListener('stop', function () {
+          const blob = new Blob(recordedChunks); // eslint-disable-line no-undef
+          const reader = new FileReader(); // eslint-disable-line no-undef
+          const fileName = `pid_${participantID}_${recorder}_${Date.now()}.webm`;
+          reader.onload = function () {
+            if (reader.readyState === 2) {
+              const buffer = Buffer.from(reader.result); // eslint-disable-line no-undef
+              ipcRenderer.send('save_video', fileName, buffer);
+              console.log(`Saving ${JSON.stringify({ fileName, size: blob.size })}`);
+            }
+          };
+          reader.readAsArrayBuffer(blob);
+        });
+      };
+
+      navigator.mediaDevices
+        .getUserMedia({ video: true })
+        .then((stream) => handleEvents(stream, 'cameraCapture'));
+
+      const { desktopCapturer } = window.require('electron');
+      desktopCapturer.getSources({ types: ['window'] }).then(async (sources) => {
+        for (const source of sources) {
+          if (source.name === TASK_NAME) {
+            navigator.mediaDevices
+              .getUserMedia({
+                video: {
+                  mandatory: {
+                    chromeMediaSource: 'desktop',
+                    chromeMediaSourceId: source.id,
+                  },
+                },
+              })
+              .then((stream) => handleEvents(stream, 'screenCapture'))
+              .catch((error) => console.log(error));
+          }
+        }
+      });
+    },
+    on_finish: () => {
+      if (config.USE_CAMERA) {
+        try {
+          window.cameraCapture.start();
+          window.screenCapture.start();
+        } catch (error) {
+          window.alert(
+            'Camera permissions were not given, if you choose to proceed, your recording will not be saved. Please restart the experiment after you have given permission.'
+          );
+        }
+      }
+    },
+  };
+}
+
+export const CameraStart = createCameraStartTrial();

--- a/src/JsPsych/trials/examples/camera/index.js
+++ b/src/JsPsych/trials/examples/camera/index.js
@@ -1,0 +1,2 @@
+export * from './CameraStart';
+export * from './CameraEnd';


### PR DESCRIPTION
Still in the midst of moving things around so theirs lots of commented out code and such - please ignore!

- Splits `camera.js` into `CameraStart` and `CameraEnd` trials

Note that JsPsych now has an [initialize-camera plugin](https://www.jspsych.org/7.3/plugins/initialize-camera/)! Will implement that and delete these trials later. Plus it won't be constrained to home use!