### PR TITLE
Reverse participantID and studyID in all functions with the former coming before the latter

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "homepage": ".",
   "repository": "https://github.com/brown-ccv/honeycomb",
   "dependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@brown-ccv/behavioral-task-trials": "^2.0.0",
     "@fortawesome/fontawesome-free": "^5.9.0",
     "@jspsych/plugin-html-button-response": "^1.1.1",
@@ -50,7 +51,7 @@
     "electron": "19.0.8",
     "eslint": "^8.38.0",
     "eslint-config-prettier": "^8.8.0",
-    "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-prettier": "^5.0.0",
     "firebase-admin": "^11.0.1",
     "firebase-tools": "^11.0.1",
     "husky": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "homepage": ".",
   "repository": "https://github.com/brown-ccv/honeycomb",
   "dependencies": {
-    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@brown-ccv/behavioral-task-trials": "^2.0.0",
     "@fortawesome/fontawesome-free": "^5.9.0",
     "@jspsych/plugin-html-button-response": "^1.1.1",
@@ -38,6 +37,7 @@
     "wait-on": "^7.0.1"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@electron-forge/cli": "^6.0.0-beta.64",
     "@electron-forge/maker-deb": "^6.0.0-beta.64",
     "@electron-forge/maker-dmg": "^6.0.0-beta.64",

--- a/public/electron.js
+++ b/public/electron.js
@@ -197,8 +197,8 @@ const today = new Date();
  * Abstracts constructing the filepath for saving data for this participant and study.
  * @returns {string} The filepath.
  */
-const getSavePath = (participantID, studyID) => {
-  if (participantID !== '' && studyID !== '') {
+const getSavePath = (studyID, participantID) => {
+  if (studyID !== '' && participantID !== '') {
     const desktop = app.getPath('desktop');
     const name = app.getName();
     const date = today.toISOString().slice(0, 10);
@@ -224,7 +224,7 @@ ipc.on('syncCredentials', (event) => {
 // listener for new data
 ipc.on('data', (event, args) => {
   // initialize file - we got a participant_id to save the data to
-  if (args.participant_id && args.study_id && !fileCreated) {
+  if (args.study_id && args.participant_id && !fileCreated) {
     const dir = app.getPath('userData');
     participantID = args.participant_id;
     studyID = args.study_id;
@@ -237,7 +237,7 @@ ipc.on('data', (event, args) => {
   }
 
   if (savePath === '') {
-    savePath = getSavePath(participantID, studyID);
+    savePath = getSavePath(studyID, participantID);
   }
 
   // we have a set up stream to write to, write to it!
@@ -258,7 +258,7 @@ ipc.on('data', (event, args) => {
 // Save Video
 ipc.on('save_video', (event, videoFileName, buffer) => {
   if (savePath === '') {
-    savePath = getSavePath(participantID, studyID);
+    savePath = getSavePath(studyID, participantID);
   }
 
   if (VIDEO) {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -64,17 +64,15 @@ function App() {
       // If MTURK
       if (config.USE_MTURK) {
         /* eslint-disable */
-        window.lodash = _.noConflict()
-        setPsiturk(new PsiTurk(turkUniqueId, '/complete'))
-        setMethod('mturk')
-        // TODO 145: Function signature
-        handleLogin('mturk', turkUniqueId)
+        window.lodash = _.noConflict();
+        setPsiturk(new PsiTurk(turkUniqueId, '/complete'));
+        setMethod('mturk');
+        handleLogin('mturk', turkUniqueId);
         /* eslint-enable */
       } else if (config.USE_PROLIFIC) {
         const pID = getProlificId();
         if (config.USE_FIREBASE && pID) {
           setMethod('firebase');
-          // TODO 145: Function signature
           handleLogin('prolific', pID);
         } else {
           // Error - Prolific must be used with Firebase
@@ -83,10 +81,10 @@ function App() {
       } else if (config.USE_FIREBASE) {
         // Fill in login fields based on query parameters (may still be blank)
         const query = new URLSearchParams(window.location.search);
-        const participantId = query.get('participantID');
         const studyId = query.get('studyID');
-        if (participantId) setParticipantID(participantId);
+        const participantId = query.get('participantID');
         if (studyId) setStudyID(studyId);
+        if (participantId) setParticipantID(participantId);
 
         setMethod('firebase');
       } else {
@@ -94,15 +92,15 @@ function App() {
       }
     }
     // eslint-disable-next-line
-  }, [])
+  }, []);
 
   /** VALIDATION FUNCTIONS */
 
   // Default to valid
   const defaultValidation = async () => true;
   // Validate participant/study against Firestore rules
-  const firebaseValidation = (participantId, studyId) => {
-    return validateParticipant(participantId, studyId);
+  const firebaseValidation = (studyId, participantId) => {
+    return validateParticipant(studyId, participantId);
   };
 
   /** DATA WRITE FUNCTIONS */
@@ -141,9 +139,9 @@ function App() {
   };
 
   // Update the study/participant data when they log in
-  const handleLogin = useCallback((participantId, studyId) => {
-    setParticipantID(participantId);
+  const handleLogin = useCallback((studyId, participantId) => {
     setStudyID(studyId);
+    setParticipantID(participantId);
     setLoggedIn(true);
   }, []);
 
@@ -160,8 +158,8 @@ function App() {
       <>
         {loggedIn ? (
           <JsPsychExperiment
-            participantId={participantID}
             studyId={studyID}
+            participantId={participantID}
             taskVersion={taskVersion}
             dataUpdateFunction={
               {
@@ -189,8 +187,8 @@ function App() {
                 firebase: firebaseValidation,
               }[currentMethod]
             }
-            initialParticipantID={participantID}
             initialStudyID={studyID}
+            initialParticipantID={participantID}
             handleLogin={handleLogin}
           />
         )}

--- a/src/components/JsPsychExperiment.jsx
+++ b/src/components/JsPsychExperiment.jsx
@@ -6,8 +6,8 @@ import { initParticipant } from '../firebase';
 import { buildTimeline, jsPsychOptions } from '../timelines/main';
 
 function JsPsychExperiment({
-  participantId,
   studyId,
+  participantId,
   taskVersion,
   dataUpdateFunction,
   dataFinishFunction,
@@ -35,18 +35,18 @@ function JsPsychExperiment({
     const startDate = new Date().toISOString();
 
     // Write the initial record to Firestore
-    if (config.USE_FIREBASE) initParticipant(participantId, studyId, startDate);
+    if (config.USE_FIREBASE) initParticipant(studyId, participantId, startDate);
 
     const jsPsych = initJsPsych(combinedOptions);
     // Add experiment properties into jsPsych directly
     jsPsych.data.addProperties({
-      participant_id: participantId,
       study_id: studyId,
+      participant_id: participantId,
       start_date: startDate,
       task_version: taskVersion,
     });
     return jsPsych;
-  }, [participantId, studyId, taskVersion]);
+  }, [studyId, participantId, taskVersion]);
 
   // Build our jspsych experiment timeline (in this case a Honeycomb demo, you could substitute your own here).
   const timeline = buildTimeline(jsPsych);

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -12,9 +12,9 @@ function Login({ handleLogin, initialParticipantID, initialStudyID, validationFu
   function handleSubmit(e) {
     e.preventDefault();
     // Logs user in if a valid participant/study id combination is given
-    validationFunction(participantId, studyId).then((isValid) => {
+    validationFunction(studyId, participantId).then((isValid) => {
       setIsError(!isValid);
-      if (isValid) handleLogin(participantId, studyId);
+      if (isValid) handleLogin(studyId, participantId);
     });
   }
 
@@ -44,7 +44,7 @@ function Login({ handleLogin, initialParticipantID, initialStudyID, validationFu
             block
             size='lg'
             type='submit'
-            disabled={participantId.length === 0 || studyId.length === 0}
+            disabled={studyId.length === 0 || participantId.length === 0}
           >
             Log In
           </Button>

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -35,8 +35,7 @@ const getExperimentRef = (studyID, participantID, startDate) =>
  * @param {string} participantID The ID of a given participant inside the studyID
  * @returns true if the given studyID & participantID combo is in Firebase, false otherwise
  */
-// TODO 174: Reverse participantID and studyID order
-async function validateParticipant(participantID, studyID) {
+async function validateParticipant(studyID, participantID) {
   try {
     // .get() will fail on an invalid path
     await getParticipantRef(studyID, participantID).get();
@@ -55,8 +54,7 @@ async function validateParticipant(participantID, studyID) {
  * @param {string} startDate The ID of a given participant inside the studyID and participantID
  * @returns true if able to initialize the new experiment, false otherwise
  */
-// TODO 174: Reverse participantID and studyID order
-async function initParticipant(participantID, studyID, startDate) {
+async function initParticipant(studyID, participantID, startDate) {
   try {
     const experiment = getExperimentRef(studyID, participantID, startDate);
     await experiment.set({


### PR DESCRIPTION
There are a few functions with `participantID` coming before `studyID`, which is inconsistent with the rest of the code base and illogical. This PR reverses the their orders in the signature of such functions.

Also updated `prettier` and added `@babel/plugin-proposal-private-property-in-object` to squash the following warning message:

```
One of your dependencies, babel-preset-react-app, is importing the
"@babel/plugin-proposal-private-property-in-object" package without
declaring it in its dependencies. This is currently working because
"@babel/plugin-proposal-private-property-in-object" is already in your
node_modules folder for unrelated reasons, but it may break at any time.

babel-preset-react-app is part of the create-react-app project, which
is not maintianed anymore. It is thus unlikely that this bug will
ever be fixed. Add "@babel/plugin-proposal-private-property-in-object" to
your devDependencies to work around this error. This will make this message
go away.
```