### PR TITLE
Enhance build timeline

### DIFF
--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -168,8 +168,8 @@ export default function App() {
     if (loggedIn) {
       return (
         <JsPsychExperiment
-          studyId={studyID}
-          participantId={participantID}
+          studyID={studyID}
+          participantID={participantID}
           taskVersion={taskVersion}
           dataUpdateFunction={
             {

--- a/src/App/components/JsPsychExperiment.jsx
+++ b/src/App/components/JsPsychExperiment.jsx
@@ -6,8 +6,8 @@ import { initParticipant } from "../deployments/firebase";
 import { buildTimeline, jsPsychOptions } from "../../timelines/main";
 
 export default function JsPsychExperiment({
-  studyId,
-  participantId,
+  studyID,
+  participantID,
   taskVersion,
   dataUpdateFunction,
   dataFinishFunction,
@@ -26,7 +26,7 @@ export default function JsPsychExperiment({
   };
 
   /**
-   * Create the instance of JsPsych whenever the studyId, participantId, or taskVersion changes,
+   * Create the instance of JsPsych whenever the studyID, participantID, or taskVersion changes,
    * which occurs then the user logs in.
    *
    * This instance of jsPsych is passed to any trials that need it when the timeline is built.
@@ -37,21 +37,21 @@ export default function JsPsychExperiment({
     const startDate = new Date().toISOString();
 
     // Write the initial record to Firestore
-    if (config.USE_FIREBASE) initParticipant(studyId, participantId, startDate);
+    if (config.USE_FIREBASE) initParticipant(studyID, participantID, startDate);
 
     const jsPsych = initJsPsych(combinedOptions);
     // Add experiment properties into jsPsych directly
     jsPsych.data.addProperties({
-      study_id: studyId,
-      participant_id: participantId,
+      study_id: studyID,
+      participant_id: participantID,
       start_date: startDate,
       task_version: taskVersion,
     });
     return jsPsych;
-  }, [studyId, participantId, taskVersion]);
+  }, [studyID, participantID, taskVersion]);
 
   // Build the experiment timeline
-  const timeline = buildTimeline(jsPsych);
+  const timeline = buildTimeline(jsPsych, studyID, participantID);
 
   /**
    * Callback function used to set up event and lifecycle callbacks to start and stop jspsych.

--- a/src/timelines/main.js
+++ b/src/timelines/main.js
@@ -18,8 +18,12 @@ const jsPsychOptions = {
  * Builds the experiment's timeline that jsPsych will run
  * The instance of jsPsych passed in will include jsPsychOptions from above
  * @param {Object} jsPsych The jsPsych instance that is running the experiment
+ * @param {*} studyID The ID of the study that was just logged into
+ * @param {*} participantID The ID of the participant that was just logged in
+ * @returns The timeline for JsPsych to run
  */
-function buildTimeline(jsPsych) {
+function buildTimeline(jsPsych, studyID, participantID) {
+  console.log(`Building timeline for ${participantID} on study ${studyID}`);
   const timeline = createHoneycombTimeline(jsPsych);
 
   // Dynamically adds the camera trials to the experiment if config.USE_CAMERA

--- a/src/timelines/main.js
+++ b/src/timelines/main.js
@@ -15,8 +15,8 @@ const jsPsychOptions = {
  * Builds the experiment's timeline that jsPsych will run
  * The instance of jsPsych passed in will include jsPsychOptions from above
  * @param {Object} jsPsych The jsPsych instance that is running the experiment
- * @param {*} studyID The ID of the study that was just logged into
- * @param {*} participantID The ID of the participant that was just logged in
+ * @param {string} studyID The ID of the study that was just logged into
+ * @param {string} participantID The ID of the participant that was just logged in
  * @returns The timeline for JsPsych to run
  */
 function buildTimeline(jsPsych, studyID, participantID) {

--- a/src/timelines/main.js
+++ b/src/timelines/main.js
@@ -7,10 +7,7 @@ import { createHoneycombTimeline } from "./honeycombTimeline";
  * Note that Honeycomb combines these with other options required for Honeycomb to operate correctly
  */
 const jsPsychOptions = {
-  on_trial_finish: function (data) {
-    console.log("A trial just ended, here are the latest data:");
-    console.log(data);
-  },
+  on_trial_finish: (data) => console.log("A trial just ended, here are the latest data:", data),
   default_iti: 250,
 };
 
@@ -23,7 +20,7 @@ const jsPsychOptions = {
  * @returns The timeline for JsPsych to run
  */
 function buildTimeline(jsPsych, studyID, participantID) {
-  console.log(`Building timeline for ${participantID} on study ${studyID}`);
+  console.log(`Building timeline for participant ${participantID} on study ${studyID}`);
   const timeline = createHoneycombTimeline(jsPsych);
 
   // Dynamically adds the camera trials to the experiment if config.USE_CAMERA

--- a/src/timelines/main.js
+++ b/src/timelines/main.js
@@ -7,7 +7,7 @@ import { createHoneycombTimeline } from "./honeycombTimeline";
  * Note that Honeycomb combines these with other options required for Honeycomb to operate correctly
  */
 const jsPsychOptions = {
-  on_trial_finish: (data) => console.log("A trial just ended, here are the latest data:", data),
+  on_trial_finish: (data) => console.log(`Trial ${data.internal_node_id} just finished:`, data),
   default_iti: 250,
 };
 


### PR DESCRIPTION
Minor style changes here. I accidentally generated a 3.2.0 release when the package.json had `3.2.1` so this nicely brings those numbers in sync too!

- `studyId` is renamed to `studyID` and passed to `buildTimeline`
- `participantId` is renamed to `participantID` and passed to `buildTimeline`
- `on_trial_finish` now logs everything in a single block