### PR TITLE
fix: Fix CLI download to work with older versions of data stored in Firebase

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "email": "ccv-bot@brown.edu",
     "url": "https://ccv.brown.edu"
   },
-  "version": "3.2.2",
+  "version": "3.2.3",
   "license": "MIT",
   "private": true,
   "main": "public/electron.js",


### PR DESCRIPTION
Older versions of Honeycomb didn't store experiment data in the nested "trials" subcollection. The CLI was overriding those results with an empty array. We now skip that step if the Firebase document doesn't have that subcollection