### PR TITLE
feat (index.html): Add a content security policy

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,43 +1,48 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <!--
+
+<head>
+  <meta charset="utf-8" />
+  <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+
+  <!-- Adds a security policy to Honeycomb
+      default (images, scripts): Only content from within the app may be loaded
+      style: Only content from within the app may be loaded, but it may be loaded inline
+      TODO: Only load fonts internally here? create-react-app defaults must still be lingering
+      fonts: Fonts may be loaded to the application via data and http sources
+  -->
+  <meta http-equiv="Content-Security-Policy"
+    content="default-src 'self'; style-src 'self' 'unsafe-inline'; font-src http: data:" />
+
+
+  <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
+  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
 
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
+  <!--
+      Notice the use of %PUBLIC_URL% in the tags above. It will be replaced 
+      with the URL of the `public` folder during the build. Only files inside 
+      the `public` folder can be referenced from the HTML. 
+      "%PUBLIC_URL%/favicon.ico" will work correctly both with client-side 
+      routing and a non-root public URL.
     -->
-    <script src="%PUBLIC_URL%/static/lib/jquery-min.js" type="text/javascript"> </script>
-    <script src="%PUBLIC_URL%/static/lib/underscore-min.js" type="text/javascript"> </script>
-    <script src="%PUBLIC_URL%/static/lib/backbone-min.js" type="text/javascript"> </script>
-    <script src="%PUBLIC_URL%/static/lib/psiturk.js" type="text/javascript"> </script>
+  <script src="%PUBLIC_URL%/static/lib/jquery-min.js" type="text/javascript"> </script>
+  <script src="%PUBLIC_URL%/static/lib/underscore-min.js" type="text/javascript"> </script>
+  <script src="%PUBLIC_URL%/static/lib/backbone-min.js" type="text/javascript"> </script>
+  <script src="%PUBLIC_URL%/static/lib/psiturk.js" type="text/javascript"> </script>
 
-    <title>Honeycomb</title>
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
+  <title>Honeycomb</title>
+</head>
 
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
 
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
-  </body>
+  <!-- Root div that holds the react application -->
+  <div id="root"></div>
+</body>
+
 </html>


### PR DESCRIPTION
Adds a content security policy to `index.html`. There's a lot of Electron documentation that points to this as a best practice