### PR TITLE
fix: Fix node gyp error when building for macOS on GitHub Action

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -31,7 +31,7 @@ jobs:
       - name: 🐍 Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
           cache: "pip"
 
       - name: "Check Python version"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,10 +32,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-          # cache: "pip"
-
-      - name: "Check Python version"
-        run: python --version
 
       # Install dependencies and set up environment
       - name: 📥 Install Dependencies

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -43,7 +43,7 @@ jobs:
           mode: ${{matrix.setting}}
 
       # Test and build the app
-      - name: 🧪 Run Lint
+      - name: 🧪 Run Test
         run: npm test
         env:
           CI: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false # A failed build will not end the other matrix jobs
 
     steps:
-      # Set up Node
+      # Set up runner
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v4
       - name: ⎔ Setup node
@@ -28,6 +28,11 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: npm
+      - name: 🐍 Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.10
+          cache: "pip"
 
       - name: "Check Python version"
         run: python --version

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -30,7 +30,7 @@ jobs:
           cache: npm
 
       - name: "Check Python version"
-        run: echo "python --version"
+        run: python --version
 
       # Install dependencies and set up environment
       - name: 📥 Install Dependencies

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -29,6 +29,9 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
 
+      - name: "Check Python version"
+        run: echo "python --version"
+
       # Install dependencies and set up environment
       - name: 📥 Install Dependencies
         run: npm ci

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-          cache: "pip"
+          # cache: "pip"
 
       - name: "Check Python version"
         run: python --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,10 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: npm
+      - name: 🐍 Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
 
       # Install dependencies and set up environment
       - name: 📥 Install Dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
     name: Deploy to GH Pages
     runs-on: ubuntu-latest
     steps:
-      # Set up Node
+      # Set up runner
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v4
       - name: ⎔ Setup node
@@ -104,6 +104,10 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: npm
+      - name: 🐍 Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
 
       # Install dependencies
       - name: 📥 Install Dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: true # A failed build will not end the other matrix jobs
 
     steps:
-      # Set up Node
+      # Set up runner
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v4
       - name: ⎔ Setup node

--- a/.github/workflows/workflow-package.yml
+++ b/.github/workflows/workflow-package.yml
@@ -47,6 +47,10 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: npm
+      - name: 🐍 Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
 
       # Install dependencies and set up environment
       - name: 📥 Install Dependencies

--- a/.github/workflows/workflow-package.yml
+++ b/.github/workflows/workflow-package.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false # A failed build will not end the other matrix jobs
 
     steps:
-      # Set up Node
+      # Set up runner
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v4
       - name: ⎔ Setup node


### PR DESCRIPTION
`npm install` on the `macOS-latest` GitHub runner is failing because of a gyp error. I'll work on a discussion post for the changes  so other labs can upgrade easily as well

- Adds `setup-python` step, uses 3.10