### PR TITLE
chore: Add blank honeycomb_version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://ccv.brown.edu"
   },
   "version": "3.2.4",
-  "honeycomb_version": "",
+  "honeycombVersion": "",
   "license": "MIT",
   "private": true,
   "main": "public/electron.js",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "email": "ccv-bot@brown.edu",
     "url": "https://ccv.brown.edu"
   },
-  "version": "3.2.3",
+  "version": "3.2.4",
+  "honeycomb_version": "",
   "license": "MIT",
   "private": true,
   "main": "public/electron.js",


### PR DESCRIPTION
Coincides with [this PR](https://github.com/brown-ccv/honeycomb-docs/pull/87) in the docs repo. I want to leave it blank so we don't have to update the `version` and `honeycomb_version` every time we make a change. If they never update the version field than it will still correctly identify the honeycomb version