### PR TITLE
ref: Change default Firebase ruleset

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -4,7 +4,11 @@ service cloud.firestore {
     // participantID must be in the registered_participants array in the registered_studies/{studyID} document
     match /participant_responses/{studyID}/participants/{participantID} {
       allow create, read: 
-      if participantID in get(/databases/$(database)/documents/registered_studies/$(studyID)).data.registered_participants;
+      // Allows any combination of studyID and participantID to be created in Firebase
+      if true
+      // Forces participantID and studyID to already be in Firebase to log in
+      // if participantID in get(/databases/$(database)/documents/registered_studies/$(studyID)).data.registered_participants;
+
 
       // experimentID must be in the data subcollection
       match /data/{experimentID} {

--- a/firestore.rules
+++ b/firestore.rules
@@ -8,7 +8,7 @@ service cloud.firestore {
       if true
       // Forces participantID and studyID to already be in Firebase to log in
       // if participantID in get(/databases/$(database)/documents/registered_studies/$(studyID)).data.registered_participants;
-
+      // TODO: Discusssion post about use cases for the different rules
 
       // experimentID must be in the data subcollection
       match /data/{experimentID} {

--- a/public/index.html
+++ b/public/index.html
@@ -16,7 +16,7 @@
   -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; style-src 'self' 'unsafe-inline'; font-src http: data:"
+      content="script-src 'self'; style-src 'self' 'unsafe-inline'; font-src http: data:"
     />
 
     <!--


### PR DESCRIPTION
This ruleset allows the creation of `participantID`s and `studyID`s at runtime when using firebase. This is needed for working with Prolific which the majority of Firebase users are using at this point. I figure I'd just change the default rather than walk each lab through the change.

Also fixes an issue with the Content-Security Policy that was preventing API access to Firebase.

_**This is a change for version 3.3 of Honeycomb, merging into  a holding branch**_