### PR TITLE
style: Eslint fails on warnings when running as a workflow

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,7 @@ module.exports = {
   plugins: ["react"],
   rules: {
     "react/prop-types": "off", // TODO: These should be added so the rule can be removed
-    "import/order": ["error"],
+    "import/order": "warn",
   },
   settings: {
     react: {

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -42,12 +42,14 @@ jobs:
           path: ./env
           mode: ${{matrix.setting}}
 
-      # Test and build the app
+      # Test and lint
       - name: 🧪 Run Test
         run: npm test
         env:
           CI: true
       - name: 🔬 Lint
-        run: npm run lint
+        run: npm run lint -- --max-warnings=0
+
+      # Build the app
       - name: ⚒ Run Build
         run: npm run build

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -43,7 +43,7 @@ jobs:
           mode: ${{matrix.setting}}
 
       # Test and lint
-      - name: 🧪 Run Test
+      - name: 🧪 Test
         run: npm test
         env:
           CI: true
@@ -51,5 +51,5 @@ jobs:
         run: npm run lint -- --max-warnings=0
 
       # Build the app
-      - name: ⚒ Run Build
+      - name: ⚒ Build
         run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           mode: ${{matrix.setting}}
 
       # Build the app
-      - name: ⚒ Run Build
+      - name: ⚒ Build
         run: npm run build
 
       # Package the app installers
@@ -114,7 +114,7 @@ jobs:
         run: npm ci
 
       # Build the app
-      - name: ⚒ Run Build
+      - name: ⚒ Build
         run: npm run build
 
       # Deploy the app to GitHub Pages
@@ -142,7 +142,7 @@ jobs:
         run: npm ci
 
       # Build the app
-      - name: ⚒ Run Build
+      - name: ⚒ Build
         run: npm run build
 
       # Package on PsiTurk

--- a/.github/workflows/workflow-package.yml
+++ b/.github/workflows/workflow-package.yml
@@ -62,7 +62,7 @@ jobs:
           mode: ${{github.event.inputs.setting}}
 
       # Build the app
-      - name: ⚒ Run Build
+      - name: ⚒ Build
         run: npm run build
 
       # Package the app installers


### PR DESCRIPTION
- Import order defaults to warnings now on eslint
- Adds `--max-warnings=0` to the lint command inside the `pull_request.yml` action