### PR TITLE
ref: Clean up `JsPsychExperiment` code

### DIFF
--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -7,7 +7,7 @@ import "jspsych/css/jspsych.css";
 import "./index.css";
 import "./App.css";
 
-import { config, taskSettings, taskVersion, turkUniqueId } from "../config/main";
+import { config, taskSettings, turkUniqueId } from "../config/main";
 import { getProlificId, getSearchParam } from "../lib/utils";
 
 // Import deployment functions
@@ -168,7 +168,6 @@ export default function App() {
         <JsPsychExperiment
           studyID={studyID}
           participantID={participantID}
-          taskVersion={taskVersion}
           dataUpdateFunction={
             {
               desktop: desktopUpdateFunction,

--- a/src/App/components/JsPsychExperiment.jsx
+++ b/src/App/components/JsPsychExperiment.jsx
@@ -52,7 +52,7 @@ export default function JsPsychExperiment({
     return jsPsych;
   }, [studyID, participantID]);
 
-  /** Builds and runs the experiment timeline */
+  /** Build and run the experiment timeline */
   React.useEffect(() => {
     const timeline = buildTimeline(jsPsych, studyID, participantID);
     jsPsych.run(timeline);

--- a/src/App/components/JsPsychExperiment.jsx
+++ b/src/App/components/JsPsychExperiment.jsx
@@ -20,7 +20,6 @@ export default function JsPsychExperiment({
    * This instance of jsPsych is passed to any trials that need it when the timeline is built.
    */
   const jsPsych = React.useMemo(() => {
-    console.log("INITIALIZING JSPSYCH");
     // TODO #169: JsPsych has a built in timestamp function
     // Start date of the experiment - used as the UID of the session
     const startDate = new Date().toISOString();

--- a/src/App/components/JsPsychExperiment.jsx
+++ b/src/App/components/JsPsychExperiment.jsx
@@ -1,21 +1,20 @@
 import { initJsPsych } from "jspsych";
 import React from "react";
 
-import { config } from "../../config/main";
+import { config, taskVersion } from "../../config/main";
 import { initParticipant } from "../deployments/firebase";
 import { buildTimeline, jsPsychOptions } from "../../timelines/main";
 
 export default function JsPsychExperiment({
   studyID,
   participantID,
-  taskVersion,
   dataUpdateFunction,
   dataFinishFunction,
 }) {
   // This will be the div in the dom that holds the experiment.
   // We reference it explicitly here so we can do some plumbing with react, jspsych, and events.
-  const experimentDivId = "experimentWindow";
   const experimentDiv = React.useRef(null);
+  const experimentDivId = "experimentWindow";
 
   // Combine custom options imported from timelines/maine.js, with necessary Honeycomb options.
   const combinedOptions = {
@@ -26,7 +25,7 @@ export default function JsPsychExperiment({
   };
 
   /**
-   * Create the instance of JsPsych whenever the studyID, participantID, or taskVersion changes,
+   * Create the instance of JsPsych whenever the studyID or participantID changes,
    * which occurs then the user logs in.
    *
    * This instance of jsPsych is passed to any trials that need it when the timeline is built.
@@ -48,7 +47,7 @@ export default function JsPsychExperiment({
       task_version: taskVersion,
     });
     return jsPsych;
-  }, [studyID, participantID, taskVersion]);
+  }, [studyID, participantID]);
 
   // Build the experiment timeline
   const timeline = buildTimeline(jsPsych, studyID, participantID);

--- a/src/App/components/JsPsychExperiment.jsx
+++ b/src/App/components/JsPsychExperiment.jsx
@@ -11,17 +11,16 @@ export default function JsPsychExperiment({
   dataUpdateFunction,
   dataFinishFunction,
 }) {
-  // This will be the div in the dom that holds the experiment.
-  // We reference it explicitly here so we can do some plumbing with react, jspsych, and events.
+  // This element in the dom that holds the experiment.
   const experimentDivId = "experimentWindow";
 
   /**
-   * Create the instance of JsPsych whenever the studyID or participantID changes,
-   * which occurs then the user logs in.
+   * Create the instance of JsPsych whenever the studyID or participantID changes, which occurs then the user logs in.
    *
    * This instance of jsPsych is passed to any trials that need it when the timeline is built.
    */
   const jsPsych = React.useMemo(() => {
+    console.log("INITIALIZING JSPSYCH");
     // TODO #169: JsPsych has a built in timestamp function
     // Start date of the experiment - used as the UID of the session
     const startDate = new Date().toISOString();
@@ -30,7 +29,7 @@ export default function JsPsychExperiment({
     if (config.USE_FIREBASE) initParticipant(studyID, participantID, startDate);
 
     const jsPsych = initJsPsych({
-      // Combine custom options (src/timelines/main.js) with necessary Honeycomb options.
+      // Combine necessary Honeycomb options with custom ones (src/timelines/main.js)
       ...jsPsychOptions,
       display_element: experimentDivId,
       on_data_update: (data) => {
@@ -50,18 +49,15 @@ export default function JsPsychExperiment({
       start_date: startDate,
       task_version: taskVersion,
     });
+
     return jsPsych;
   }, [studyID, participantID]);
 
-  // Build the experiment timeline
-  const timeline = buildTimeline(jsPsych, studyID, participantID);
-
-  /**
-   * These useEffect callbacks manage keyboard events between React and the JsPsych experiment
-   */
+  /** Builds and runs the experiment timeline */
   React.useEffect(() => {
+    const timeline = buildTimeline(jsPsych, studyID, participantID);
     jsPsych.run(timeline);
-  });
+  }, [jsPsych]);
 
   return <div id={experimentDivId} className="App" />;
 }

--- a/src/App/components/JsPsychExperiment.jsx
+++ b/src/App/components/JsPsychExperiment.jsx
@@ -41,7 +41,7 @@ export default function JsPsychExperiment({
       },
     });
 
-    // Add experiment properties into jsPsych directly
+    // Adds experiment data into jsPsych directly. These properties will be added to all trials
     jsPsych.data.addProperties({
       study_id: studyID,
       participant_id: participantID,

--- a/src/App/components/JsPsychExperiment.jsx
+++ b/src/App/components/JsPsychExperiment.jsx
@@ -13,16 +13,7 @@ export default function JsPsychExperiment({
 }) {
   // This will be the div in the dom that holds the experiment.
   // We reference it explicitly here so we can do some plumbing with react, jspsych, and events.
-  const experimentDiv = React.useRef(null);
   const experimentDivId = "experimentWindow";
-
-  // Combine custom options imported from timelines/maine.js, with necessary Honeycomb options.
-  const combinedOptions = {
-    ...jsPsychOptions,
-    display_element: experimentDivId,
-    on_data_update: (data) => dataUpdateFunction(data),
-    on_finish: (data) => dataFinishFunction(data),
-  };
 
   /**
    * Create the instance of JsPsych whenever the studyID or participantID changes,
@@ -38,7 +29,20 @@ export default function JsPsychExperiment({
     // Write the initial record to Firestore
     if (config.USE_FIREBASE) initParticipant(studyID, participantID, startDate);
 
-    const jsPsych = initJsPsych(combinedOptions);
+    const jsPsych = initJsPsych({
+      // Combine custom options (src/timelines/main.js) with necessary Honeycomb options.
+      ...jsPsychOptions,
+      display_element: experimentDivId,
+      on_data_update: (data) => {
+        jsPsychOptions.on_data_update && jsPsychOptions.on_data_update(data); // Call custom on_data_update function (if provided)
+        dataUpdateFunction(data); // Call Honeycomb's on_data_update function
+      },
+      on_finish: (data) => {
+        jsPsychOptions.on_finish && jsPsychOptions.on_finish(data); // Call custom on_finish function (if provided)
+        dataFinishFunction(data); // Call Honeycomb's on_finish function
+      },
+    });
+
     // Add experiment properties into jsPsych directly
     jsPsych.data.addProperties({
       study_id: studyID,
@@ -53,37 +57,11 @@ export default function JsPsychExperiment({
   const timeline = buildTimeline(jsPsych, studyID, participantID);
 
   /**
-   * Callback function used to set up event and lifecycle callbacks to start and stop jspsych.
-   * Inspired by jspsych-react: https://github.com/makebrainwaves/jspsych-react/blob/master/src/index.js
-   * @param {*} e
-   * @returns
-   */
-  const handleKeyEvent = React.useCallback((e) => {
-    if (e.redispatched) return;
-
-    const newEvent = new e.constructor(e.type, e);
-    newEvent.redispatched = true;
-    experimentDiv.current.dispatchEvent(newEvent);
-  }, []);
-
-  /**
    * These useEffect callbacks manage keyboard events between React and the JsPsych experiment
    */
   React.useEffect(() => {
-    window.addEventListener("keyup", handleKeyEvent, true);
-    window.addEventListener("keydown", handleKeyEvent, true);
     jsPsych.run(timeline);
-
-    return () => {
-      window.removeEventListener("keyup", handleKeyEvent, true);
-      window.removeEventListener("keydown", handleKeyEvent, true);
-      try {
-        jsPsych.endExperiment("Ended Experiment");
-      } catch (e) {
-        console.error("Experiment closed before unmount");
-      }
-    };
   });
 
-  return <div id={experimentDivId} ref={experimentDiv} className="App" />;
+  return <div id={experimentDivId} className="App" />;
 }

--- a/src/App/components/JsPsychExperiment.jsx
+++ b/src/App/components/JsPsychExperiment.jsx
@@ -5,15 +5,15 @@ import { config, taskVersion } from "../../config/main";
 import { initParticipant } from "../deployments/firebase";
 import { buildTimeline, jsPsychOptions } from "../../timelines/main";
 
+// ID used to identify the DOM element that holds the experiment.
+const EXPERIMENT_ID = "experimentWindow";
+
 export default function JsPsychExperiment({
   studyID,
   participantID,
   dataUpdateFunction,
   dataFinishFunction,
 }) {
-  // This element in the dom that holds the experiment.
-  const experimentDivId = "experimentWindow";
-
   /**
    * Create the instance of JsPsych whenever the studyID or participantID changes, which occurs then the user logs in.
    *
@@ -31,7 +31,7 @@ export default function JsPsychExperiment({
     const jsPsych = initJsPsych({
       // Combine necessary Honeycomb options with custom ones (src/timelines/main.js)
       ...jsPsychOptions,
-      display_element: experimentDivId,
+      display_element: EXPERIMENT_ID,
       on_data_update: (data) => {
         jsPsychOptions.on_data_update && jsPsychOptions.on_data_update(data); // Call custom on_data_update function (if provided)
         dataUpdateFunction(data); // Call Honeycomb's on_data_update function
@@ -59,5 +59,5 @@ export default function JsPsychExperiment({
     jsPsych.run(timeline);
   }, [jsPsych]);
 
-  return <div id={experimentDivId} className="App" />;
+  return <div id={EXPERIMENT_ID} className="App" />;
 }

--- a/src/timelines/honeycombBlock.js
+++ b/src/timelines/honeycombBlock.js
@@ -28,6 +28,7 @@ function createHoneycombBlock(jsPsych) {
    * Note that the correct_response is saved as a data point
    * Note that the trial calculates and saves if the user responded correctly on trial_finish
    */
+  // TODO #332: Add photodiode and event marker code here
   const taskTrial = {
     type: imageKeyboardResponse,
     // Display a stimulus passed as a timeline variable

--- a/src/timelines/main.js
+++ b/src/timelines/main.js
@@ -8,7 +8,6 @@ import { createHoneycombTimeline } from "./honeycombTimeline";
  */
 const jsPsychOptions = {
   on_trial_finish: (data) => console.log(`Trial ${data.internal_node_id} just finished:`, data),
-  default_iti: 250,
 };
 
 /**

--- a/src/timelines/main.js
+++ b/src/timelines/main.js
@@ -7,7 +7,8 @@ import { createHoneycombTimeline } from "./honeycombTimeline";
  * Note that Honeycomb combines these with other options required for Honeycomb to operate correctly
  */
 const jsPsychOptions = {
-  on_trial_finish: (data) => console.log(`Trial ${data.internal_node_id} just finished:`, data),
+  // TEMP
+  // on_trial_finish: (data) => console.log(`Trial ${data.internal_node_id} just finished:`, data),
 };
 
 /**

--- a/src/timelines/main.js
+++ b/src/timelines/main.js
@@ -7,8 +7,7 @@ import { createHoneycombTimeline } from "./honeycombTimeline";
  * Note that Honeycomb combines these with other options required for Honeycomb to operate correctly
  */
 const jsPsychOptions = {
-  // TEMP
-  // on_trial_finish: (data) => console.log(`Trial ${data.internal_node_id} just finished:`, data),
+  on_trial_finish: (data) => console.log(`Trial ${data.internal_node_id} just finished:`, data),
 };
 
 /**


### PR DESCRIPTION
- Remove unneeded event listeners
- Moves `taskVersion` import directly into `JsPsychExperiment`
- Moves merging of `jsPsychOptions` to inside the memo
- `on_data_uptdate` and `on_finish` options are now properly merged
- `buildTimeline` is moved inside the `useEffect`
- Removes the task's default "inter-trial interval" (most labs have asked to remove this anyways)