### PR TITLE
ref: Remove usage of showMessage trial 

### DIFF
--- a/src/trials/honeycombTrials.js
+++ b/src/trials/honeycombTrials.js
@@ -1,10 +1,9 @@
-import { showMessage } from "@brown-ccv/behavioral-task-trials";
 import htmlKeyboardResponse from "@jspsych/plugin-html-keyboard-response";
 import instructionsResponse from "@jspsych/plugin-instructions";
 import preloadResponse from "@jspsych/plugin-preload";
 
-import { config, eventCodes, LANGUAGE, SETTINGS } from "../config/main";
-import { b, div, image, p } from "../lib/markup/tags";
+import { eventCodes, LANGUAGE, SETTINGS } from "../config/main";
+import { b, div, h1, image, p } from "../lib/markup/tags";
 
 const honeycombLanguage = LANGUAGE.trials.honeycomb;
 
@@ -82,11 +81,12 @@ function buildDebriefTrial(jsPsych) {
 }
 
 /** Trial that displays a completion message for 5 seconds */
-// TODO #365: Bring showMessage trial directly into HC and update
 // TODO #367: Use trial inside endBlock
-const finishTrial = showMessage(config, {
-  duration: 5000,
-  message: honeycombLanguage.finish,
-});
+const finishTrial = {
+  type: htmlKeyboardResponse,
+  stimulus: h1(honeycombLanguage.finish),
+  choices: "NO_KEYS",
+  trial_duration: 5000,
+};
 
 export { buildDebriefTrial, finishTrial, instructionsTrial, preloadTrial };

--- a/src/trials/welcome.js
+++ b/src/trials/welcome.js
@@ -1,5 +1,3 @@
-import { showMessage } from "@brown-ccv/behavioral-task-trials";
-import htmlButtonResponse from "@jspsych/plugin-html-button-response";
 import htmlKeyboardResponse from "@jspsych/plugin-html-keyboard-response";
 
 import { config, eventCodes, LANGUAGE } from "../config/main";
@@ -7,12 +5,12 @@ import { pdSpotEncode, photodiodeGhostBox } from "../lib/markup/photodiode";
 import { div, h1 } from "../lib/markup/tags";
 
 /** Task that displays the name of the experiment */
-const nameTrial = showMessage(config, {
-  responseType: htmlButtonResponse,
-  message: LANGUAGE.name,
-  responseEndsTrial: true,
-  buttons: [LANGUAGE.prompts.continue.button],
-});
+const nameTrial = {
+  type: htmlKeyboardResponse,
+  stimulus: h1(LANGUAGE.name),
+  choices: "NO_KEYS",
+  trial_duration: 1000,
+};
 // TODO #292: Turn into jsPsych NO_KEYS trial
 // TODO #365: Move showMessage into this repo?
 

--- a/src/trials/welcome.js
+++ b/src/trials/welcome.js
@@ -11,8 +11,6 @@ const nameTrial = {
   choices: "NO_KEYS",
   trial_duration: 1000,
 };
-// TODO #292: Turn into jsPsych NO_KEYS trial
-// TODO #365: Move showMessage into this repo?
 
 /** Task that displays a welcome message with the photodiode ghost box */
 const welcomeTrial = {
@@ -35,7 +33,5 @@ const welcomeTrial = {
   },
   response_ends_trial: true,
 };
-// TODO #292: Turn into jsPsych NO_KEYS trial
-// TODO #365: Move showMessage into this repo?
 
 export { nameTrial, welcomeTrial };


### PR DESCRIPTION
- Removes the calls to `showMessage` from the [behavioral-task-trials](https://github.com/brown-ccv/behavioral-task-trials/blob/main/trials/showMessage.js) library
- Refactors `nameTrial` to be a `NO_KEYS` trial that shows the stimulus for one second
- Refactors `finishTrial` to be a `NO_KEYS` trial that shows the stimulus for 5 seconds


closes #292 
closes #365 