### PR TITLE
ref: Rename `preamble` as `startBlock`

### DIFF
--- a/src/timelines/honeycombBlock.js
+++ b/src/timelines/honeycombBlock.js
@@ -6,11 +6,13 @@ import { buildFixationTrial } from "../trials/fixation";
 
 /**
  * Builds the blocks of trials that form the core of the Honeycomb experiment
- *
  * 1) A fixation dot is shown at the center of the screen
  * 2) The stimulus image is shown and the user is prompted to press the correct key
  *
  * Note that the block is conditionally rendered and repeated based on the task settings
+ *
+ * @param {Object} jsPsych The jsPsych instance being used to run the task
+ * @returns {Object} A jsPsych (nested) timeline object
  */
 function buildHoneycombBlock(jsPsych) {
   const honeycombSettings = SETTINGS.honeycomb;

--- a/src/timelines/honeycombBlock.js
+++ b/src/timelines/honeycombBlock.js
@@ -13,7 +13,6 @@ import { buildFixationTrial } from "../trials/fixation";
  * Note that the block is conditionally rendered and repeated based on the task settings
  */
 function buildHoneycombBlock(jsPsych) {
-  // TODO #371: These settings should be passed as a parameter to the function
   const honeycombSettings = SETTINGS.honeycomb;
 
   const fixationTrial = buildFixationTrial(jsPsych);

--- a/src/timelines/honeycombBlock.js
+++ b/src/timelines/honeycombBlock.js
@@ -5,7 +5,7 @@ import { photodiodeGhostBox, pdSpotEncode } from "../lib/markup/photodiode";
 import { buildFixationTrial } from "../trials/fixation";
 
 /**
- * Builds the blocks of trials that form the core of the Honeycomb experiment
+ * Builds the block of trials that form the core of the Honeycomb experiment
  * 1) A fixation dot is shown at the center of the screen
  * 2) The stimulus image is shown and the user is prompted to press the correct key
  *

--- a/src/timelines/honeycombTimeline.js
+++ b/src/timelines/honeycombTimeline.js
@@ -7,7 +7,7 @@ import {
 } from "../trials/honeycombTrials";
 
 import { buildHoneycombBlock } from "./honeycombBlock";
-import { buildPreambleBlock } from "./preamble";
+import { buildStartBlock } from "./startBlock";
 
 /**
  * This timeline builds the example reaction time task from the jsPsych tutorial.
@@ -16,20 +16,22 @@ import { buildPreambleBlock } from "./preamble";
  * See the jsPsych documentation for more: https://www.jspsych.org/7.3/tutorials/rt-task/
  */
 function buildHoneycombTimeline(jsPsych) {
-  const preambleBlock = buildPreambleBlock();
+  // Build the trials that make up the start block
+  const startBlock = buildStartBlock();
 
-  // The first block repeats 5 times
-  // TODO #371: Pull from config here and pass into function
+  // Build the trials that make up the Honeycomb block
   const honeycombBlock = buildHoneycombBlock(jsPsych);
 
+  // TODO #367: Move to end of the honeycombBlock?
   const debriefTrial = buildDebriefTrial(jsPsych);
 
   const timeline = [
-    preambleBlock,
+    startBlock,
     preloadTrial,
     instructionsTrial,
     honeycombBlock,
     debriefTrial,
+    // TODO #367: Move to endBlock
     finishTrial,
     exitFullscreenTrial,
   ];

--- a/src/timelines/honeycombTimeline.js
+++ b/src/timelines/honeycombTimeline.js
@@ -12,12 +12,14 @@ import { buildStartBlock } from "./startBlock";
 /**
  * This timeline builds the example reaction time task from the jsPsych tutorial.
  * Take a look at how the code here compares to the jsPsych documentation!
- *
  * See the jsPsych documentation for more: https://www.jspsych.org/7.3/tutorials/rt-task/
+ *
+ * @param {Object} jsPsych The jsPsych instance being used to run the task
+ * @returns {Object} A jsPsych timeline object
  */
 function buildHoneycombTimeline(jsPsych) {
   // Build the trials that make up the start block
-  const startBlock = buildStartBlock();
+  const startBlock = buildStartBlock(jsPsych);
 
   // Build the trials that make up the Honeycomb block
   const honeycombBlock = buildHoneycombBlock(jsPsych);

--- a/src/timelines/main.js
+++ b/src/timelines/main.js
@@ -1,5 +1,6 @@
 import { config } from "../config/main";
-import { buildCameraEndTrial, buildCameraStartTrial } from "../trials/camera";
+
+import { buildCameraEndTrial } from "../trials/camera";
 
 import { buildHoneycombTimeline } from "./honeycombTimeline";
 
@@ -33,7 +34,6 @@ function buildTimeline(jsPsych, studyID, participantID) {
   // Dynamically adds the camera trials to the experiment if config.USE_CAMERA
   // TODO #367: These should be a part of the start and end blocks
   if (config.USE_CAMERA) {
-    timeline.unshift(buildCameraStartTrial(jsPsych)); // Add buildCameraStartTrial as the first trial
     timeline.push(buildCameraEndTrial(jsPsych)); // Add buildCameraEndTrial as the last trial
   }
 

--- a/src/timelines/main.js
+++ b/src/timelines/main.js
@@ -26,11 +26,13 @@ const jsPsychOptions = {
  */
 function buildTimeline(jsPsych, studyID, participantID) {
   console.log(`Building timeline for participant ${participantID} on study ${studyID}`);
+
+  // Build all of the trials consisting of the Honeycomb task
   const timeline = buildHoneycombTimeline(jsPsych);
 
   // Dynamically adds the camera trials to the experiment if config.USE_CAMERA
+  // TODO #367: These should be a part of the start and end blocks
   if (config.USE_CAMERA) {
-    // TODO #367: These should be a part of the start and end blocks
     timeline.unshift(buildCameraStartTrial(jsPsych)); // Add buildCameraStartTrial as the first trial
     timeline.push(buildCameraEndTrial(jsPsych)); // Add buildCameraEndTrial as the last trial
   }

--- a/src/timelines/startBlock.js
+++ b/src/timelines/startBlock.js
@@ -27,7 +27,9 @@ function buildStartBlock(jsPsych) {
   }
 
   // Conditionally add the camera setup trials
-  if (config.USE_CAMERA) timeline.push(buildCameraStartTrial(jsPsych));
+  if (config.USE_CAMERA) {
+    timeline.push(buildCameraStartTrial(jsPsych));
+  }
 
   return { timeline };
 }

--- a/src/timelines/startBlock.js
+++ b/src/timelines/startBlock.js
@@ -1,13 +1,23 @@
 import { config } from "../config/main";
 
+import { buildCameraStartTrial } from "../trials/camera";
 import { enterFullscreenTrial } from "../trials/fullscreen";
 import { holdUpMarkerTrial } from "../trials/holdUpMarker";
 import { startCodeTrial } from "../trials/startCode";
-import { welcomeTrial, nameTrial } from "../trials/welcome";
+import { nameTrial, welcomeTrial } from "../trials/welcome";
 
 /** Builds the blocks of trials needed to start and setup the experiment */
-function buildStartBlock() {
-  const timeline = [nameTrial, enterFullscreenTrial, welcomeTrial];
+
+/**
+ *
+ * @param {Object} jsPsych The jsPsych instance being used to run the task
+ * @returns {Object} A jsPsych (nested) timeline object
+ */
+function buildStartBlock(jsPsych) {
+  const timeline = [];
+  if (config.USE_CAMERA) timeline.push(buildCameraStartTrial(jsPsych)); // Add buildCameraStartTrial as the first trial
+
+  // const timeline = [nameTrial, enterFullscreenTrial, welcomeTrial];
 
   // Conditionally add the photodiode setup trials
   if (config.USE_PHOTODIODE) {

--- a/src/timelines/startBlock.js
+++ b/src/timelines/startBlock.js
@@ -6,7 +6,7 @@ import { startCodeTrial } from "../trials/startCode";
 import { welcomeTrial, nameTrial } from "../trials/welcome";
 
 /** Builds the blocks of trials needed to start and setup the experiment */
-function buildPreambleBlock() {
+function buildStartBlock() {
   const timeline = [nameTrial, enterFullscreenTrial, welcomeTrial];
 
   // Conditionally add the photodiode setup trials
@@ -18,4 +18,4 @@ function buildPreambleBlock() {
   return { timeline };
 }
 
-export { buildPreambleBlock };
+export { buildStartBlock };

--- a/src/timelines/startBlock.js
+++ b/src/timelines/startBlock.js
@@ -14,10 +14,10 @@ import { nameTrial, welcomeTrial } from "../trials/welcome";
  * @returns {Object} A jsPsych (nested) timeline object
  */
 function buildStartBlock(jsPsych) {
-  const timeline = [];
-  if (config.USE_CAMERA) timeline.push(buildCameraStartTrial(jsPsych)); // Add buildCameraStartTrial as the first trial
+  const timeline = [nameTrial, enterFullscreenTrial, welcomeTrial];
 
-  // const timeline = [nameTrial, enterFullscreenTrial, welcomeTrial];
+  // Conditionally add the camera setup trials
+  if (config.USE_CAMERA) timeline.push(buildCameraStartTrial(jsPsych));
 
   // Conditionally add the photodiode setup trials
   if (config.USE_PHOTODIODE) {

--- a/src/timelines/startBlock.js
+++ b/src/timelines/startBlock.js
@@ -6,9 +6,13 @@ import { holdUpMarkerTrial } from "../trials/holdUpMarker";
 import { startCodeTrial } from "../trials/startCode";
 import { nameTrial, welcomeTrial } from "../trials/welcome";
 
-/** Builds the blocks of trials needed to start and setup the experiment */
-
 /**
+ * Builds the block of trials needed to start and setup the experiment
+ * 1) The name of the experiment is displayed
+ * 2) The experiment enters fullscreen
+ * 3) A welcome message is displayed
+ * 4) Trials used to set up a photodiode and trigger box are displayed (if applicable)
+ * 5) Trials used to set up the user's camera are displayed (if applicable)
  *
  * @param {Object} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych (nested) timeline object
@@ -16,14 +20,14 @@ import { nameTrial, welcomeTrial } from "../trials/welcome";
 function buildStartBlock(jsPsych) {
   const timeline = [nameTrial, enterFullscreenTrial, welcomeTrial];
 
-  // Conditionally add the camera setup trials
-  if (config.USE_CAMERA) timeline.push(buildCameraStartTrial(jsPsych));
-
   // Conditionally add the photodiode setup trials
   if (config.USE_PHOTODIODE) {
     timeline.push(holdUpMarkerTrial);
     timeline.push(startCodeTrial);
   }
+
+  // Conditionally add the camera setup trials
+  if (config.USE_CAMERA) timeline.push(buildCameraStartTrial(jsPsych));
 
   return { timeline };
 }


### PR DESCRIPTION
- Renames `preamble` as `startBlock` to match the naming convention of other nested timelines
- Moves camera setup trials into `startBlock`
- Changes the order of the trials in startblock:
     1) The name of the experiment is displayed
     2) The experiment enters fullscreen
     3) A welcome message is displayed
     4) Trials used to set up a photodiode and trigger box are displayed (if applicable)
     5) Trials used to set up the user's camera are displayed (if applicable).  


closes #366 