### PR TITLE
ref: Add endBlock file and move trials into it

### DIFF
--- a/src/config/language.json
+++ b/src/config/language.json
@@ -1,6 +1,5 @@
 {
   "name": "Honeycomb Task",
-  "welcome": "Welcome to the experiment. Press any key to begin.",
   "prompts": {
     "continue": {
       "prompt": "Press any key to continue.",
@@ -9,6 +8,7 @@
     "settingUp": "Setting up..."
   },
   "trials": {
+    "welcome": "Welcome to the experiment. Press any key to begin.",
     "honeycomb": {
       "instructions": {
         "read": "Please read the following instructions carefully.",
@@ -30,8 +30,7 @@
           "end": "ms."
         },
         "complete": "Press any key to complete the experiment. Thank you!"
-      },
-      "finish": "This experiment has ended."
+      }
     },
     "adjustVolume": "Set tablet volume to 50/100.",
     "camera": {
@@ -147,6 +146,7 @@
       "debriefing": {
         "confirm_completion": "Confirm Completion"
       }
-    }
+    },
+    "conclusion": "The experiment has concluded. Thank you for participating."
   }
 }

--- a/src/timelines/endBlock.js
+++ b/src/timelines/endBlock.js
@@ -1,3 +1,5 @@
+import { config } from "../config/main";
+import { buildCameraEndTrial } from "../trials/camera";
 import { conclusionTrial } from "../trials/conclusion";
 import { exitFullscreenTrial } from "../trials/fullscreen";
 
@@ -9,8 +11,19 @@ import { exitFullscreenTrial } from "../trials/fullscreen";
  * @param {Object} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych (nested) timeline object
  */
-const endBlock = {
-  timeline: [exitFullscreenTrial, conclusionTrial],
-};
+function buildEndBlock(jsPsych) {
+  const endBlock = [];
 
-export { endBlock };
+  // Conditionally add the camera breakdown trials
+  if (config.USE_CAMERA) {
+    endBlock.push(buildCameraEndTrial(jsPsych));
+  }
+
+  // Add the other trials needed to end the experiment
+  endBlock.push(exitFullscreenTrial, conclusionTrial);
+
+  // Return the block as a nested timeline
+  return { timeline: endBlock };
+}
+
+export { buildEndBlock };

--- a/src/timelines/endBlock.js
+++ b/src/timelines/endBlock.js
@@ -1,0 +1,16 @@
+import { conclusionTrial } from "../trials/conclusion";
+import { exitFullscreenTrial } from "../trials/fullscreen";
+
+/**
+ * Builds the block of trials needed to end the experiment
+ * 1) Trial used to complete the user's camera recording is displayed
+ * 2) The experiment exits fullscreen
+ *
+ * @param {Object} jsPsych The jsPsych instance being used to run the task
+ * @returns {Object} A jsPsych (nested) timeline object
+ */
+const endBlock = {
+  timeline: [exitFullscreenTrial, conclusionTrial],
+};
+
+export { endBlock };

--- a/src/timelines/honeycombTimeline.js
+++ b/src/timelines/honeycombTimeline.js
@@ -1,6 +1,6 @@
 import { buildDebriefTrial, instructionsTrial, preloadTrial } from "../trials/honeycombTrials";
 
-import { endBlock } from "./endBlock";
+import { buildEndBlock } from "./endBlock";
 import { buildHoneycombBlock } from "./honeycombBlock";
 import { buildStartBlock } from "./startBlock";
 
@@ -13,12 +13,24 @@ import { buildStartBlock } from "./startBlock";
  * @returns {Object} A jsPsych timeline object
  */
 function buildHoneycombTimeline(jsPsych) {
+  // Build the trials that make up the start block
+  const startBlock = buildStartBlock(jsPsych);
+
+  // Build the trials that make up the Honeycomb block
+  const honeycombBlock = buildHoneycombBlock(jsPsych);
+
+  // Builds the trial needed to debrief the participant on their performance
+  const debriefTrial = buildDebriefTrial(jsPsych);
+
+  // Builds the trials that make up the end block
+  const endBlock = buildEndBlock(jsPsych);
+
   const timeline = [
-    buildStartBlock(jsPsych), // Build the trials that make up the start block
+    startBlock,
     preloadTrial,
     instructionsTrial,
-    buildHoneycombBlock(jsPsych), // Build the trials that make up the Honeycomb block
-    buildDebriefTrial(jsPsych), // Builds the trial needed to debrief the participant on their performance
+    honeycombBlock,
+    debriefTrial,
     endBlock,
   ];
   return timeline;

--- a/src/timelines/honeycombTimeline.js
+++ b/src/timelines/honeycombTimeline.js
@@ -1,11 +1,6 @@
-import { exitFullscreenTrial } from "../trials/fullscreen";
-import {
-  buildDebriefTrial,
-  finishTrial,
-  instructionsTrial,
-  preloadTrial,
-} from "../trials/honeycombTrials";
+import { buildDebriefTrial, instructionsTrial, preloadTrial } from "../trials/honeycombTrials";
 
+import { endBlock } from "./endBlock";
 import { buildHoneycombBlock } from "./honeycombBlock";
 import { buildStartBlock } from "./startBlock";
 
@@ -18,24 +13,13 @@ import { buildStartBlock } from "./startBlock";
  * @returns {Object} A jsPsych timeline object
  */
 function buildHoneycombTimeline(jsPsych) {
-  // Build the trials that make up the start block
-  const startBlock = buildStartBlock(jsPsych);
-
-  // Build the trials that make up the Honeycomb block
-  const honeycombBlock = buildHoneycombBlock(jsPsych);
-
-  // TODO #367: Move to end of the honeycombBlock?
-  const debriefTrial = buildDebriefTrial(jsPsych);
-
   const timeline = [
-    startBlock,
+    buildStartBlock(jsPsych), // Build the trials that make up the start block
     preloadTrial,
     instructionsTrial,
-    honeycombBlock,
-    debriefTrial,
-    // TODO #367: Move to endBlock
-    finishTrial,
-    exitFullscreenTrial,
+    buildHoneycombBlock(jsPsych), // Build the trials that make up the Honeycomb block
+    buildDebriefTrial(jsPsych), // Builds the trial needed to debrief the participant on their performance
+    endBlock,
   ];
   return timeline;
 }

--- a/src/timelines/main.js
+++ b/src/timelines/main.js
@@ -1,7 +1,3 @@
-import { config } from "../config/main";
-
-import { buildCameraEndTrial } from "../trials/camera";
-
 import { buildHoneycombTimeline } from "./honeycombTimeline";
 
 // Add CSS styling from jsPsych
@@ -15,6 +11,7 @@ import "../lib/markup/trials.css";
  */
 const jsPsychOptions = {
   on_trial_finish: (data) => console.log(`Trial ${data.internal_node_id} just finished:`, data),
+  on_finish: (data) => console.log("The experiment has finished:", data),
 };
 
 /**
@@ -30,13 +27,6 @@ function buildTimeline(jsPsych, studyID, participantID) {
 
   // Build all of the trials consisting of the Honeycomb task
   const timeline = buildHoneycombTimeline(jsPsych);
-
-  // Dynamically adds the camera trials to the experiment if config.USE_CAMERA
-  // TODO #367: These should be a part of the start and end blocks
-  if (config.USE_CAMERA) {
-    timeline.push(buildCameraEndTrial(jsPsych)); // Add buildCameraEndTrial as the last trial
-  }
-
   return timeline;
 }
 

--- a/src/timelines/startBlock.js
+++ b/src/timelines/startBlock.js
@@ -18,20 +18,21 @@ import { nameTrial, welcomeTrial } from "../trials/welcome";
  * @returns {Object} A jsPsych (nested) timeline object
  */
 function buildStartBlock(jsPsych) {
-  const timeline = [nameTrial, enterFullscreenTrial, welcomeTrial];
+  const startBlock = [nameTrial, enterFullscreenTrial, welcomeTrial];
 
   // Conditionally add the photodiode setup trials
   if (config.USE_PHOTODIODE) {
-    timeline.push(holdUpMarkerTrial);
-    timeline.push(startCodeTrial);
+    startBlock.push(holdUpMarkerTrial);
+    startBlock.push(startCodeTrial);
   }
 
   // Conditionally add the camera setup trials
   if (config.USE_CAMERA) {
-    timeline.push(buildCameraStartTrial(jsPsych));
+    startBlock.push(buildCameraStartTrial(jsPsych));
   }
 
-  return { timeline };
+  // Return the block as a nested timeline
+  return { timeline: startBlock };
 }
 
 export { buildStartBlock };

--- a/src/trials/conclusion.js
+++ b/src/trials/conclusion.js
@@ -4,7 +4,6 @@ import { LANGUAGE } from "../config/main";
 import { h1 } from "../lib/markup/tags";
 
 /** Trial that displays a completion message for 5 seconds */
-// TODO #367: Use trial inside endBlock
 const conclusionTrial = {
   type: htmlKeyboardResponse,
   stimulus: h1(LANGUAGE.trials.conclusion),

--- a/src/trials/conclusion.js
+++ b/src/trials/conclusion.js
@@ -1,0 +1,15 @@
+import htmlKeyboardResponse from "@jspsych/plugin-html-keyboard-response";
+
+import { LANGUAGE } from "../config/main";
+import { h1 } from "../lib/markup/tags";
+
+/** Trial that displays a completion message for 5 seconds */
+// TODO #367: Use trial inside endBlock
+const conclusionTrial = {
+  type: htmlKeyboardResponse,
+  stimulus: h1(LANGUAGE.trials.conclusion),
+  choices: "NO_KEYS",
+  trial_duration: 5000,
+};
+
+export { conclusionTrial };

--- a/src/trials/fixation.js
+++ b/src/trials/fixation.js
@@ -17,7 +17,6 @@ export function buildFixationTrial(jsPsych) {
   return {
     type: htmlKeyboardResponse,
     choices: "NO_KEYS",
-    response_ends_trial: false,
     // Display the fixation dot
     stimulus: div("", { id: "fixation-dot" }),
     prompt: () => {

--- a/src/trials/fixation.js
+++ b/src/trials/fixation.js
@@ -16,6 +16,8 @@ export function buildFixationTrial(jsPsych) {
 
   return {
     type: htmlKeyboardResponse,
+    choices: "NO_KEYS",
+    response_ends_trial: false,
     // Display the fixation dot
     stimulus: div("", { id: "fixation-dot" }),
     prompt: () => {
@@ -23,7 +25,6 @@ export function buildFixationTrial(jsPsych) {
       if (config.USE_PHOTODIODE) return photodiodeGhostBox;
       else return null;
     },
-    response_ends_trial: false,
     trial_duration: () => {
       if (fixationSettings.randomize_duration) {
         // Select a random duration from the durations array to show the fixation dot for

--- a/src/trials/honeycombTrials.js
+++ b/src/trials/honeycombTrials.js
@@ -3,7 +3,7 @@ import instructionsResponse from "@jspsych/plugin-instructions";
 import preloadResponse from "@jspsych/plugin-preload";
 
 import { eventCodes, LANGUAGE, SETTINGS } from "../config/main";
-import { b, div, h1, image, p } from "../lib/markup/tags";
+import { b, div, image, p } from "../lib/markup/tags";
 
 const honeycombLanguage = LANGUAGE.trials.honeycomb;
 
@@ -80,13 +80,4 @@ function buildDebriefTrial(jsPsych) {
   };
 }
 
-/** Trial that displays a completion message for 5 seconds */
-// TODO #367: Use trial inside endBlock
-const finishTrial = {
-  type: htmlKeyboardResponse,
-  stimulus: h1(honeycombLanguage.finish),
-  choices: "NO_KEYS",
-  trial_duration: 5000,
-};
-
-export { buildDebriefTrial, finishTrial, instructionsTrial, preloadTrial };
+export { buildDebriefTrial, instructionsTrial, preloadTrial };

--- a/src/trials/welcome.js
+++ b/src/trials/welcome.js
@@ -16,7 +16,7 @@ const nameTrial = {
 const welcomeTrial = {
   type: htmlKeyboardResponse,
   stimulus: () => {
-    const welcomeMarkup = h1(LANGUAGE.welcome);
+    const welcomeMarkup = h1(LANGUAGE.trials.welcome);
     return div(welcomeMarkup, { class: "bottom-prompt" }) + photodiodeGhostBox;
   },
   prompt: () => {


### PR DESCRIPTION
- Adds an `endBlock.js` file for trials needed to conclude the experiment
- Renames `finishTrial` as `conclusionTrial`
- Moves `conclusionTrial` in `trials/conclusion.js`
- Moves `exitFullScreenTrial` and `conclusionTrial`  into `endBlock.js`
- Moves `buildCameraEndTrial` into `endBlock`
- Renames `finish` sentence to `conclusion`
- Moves `welcome` and `conclusion` sentences into `LANGUAGE.trials`
- Renames `timeline` variable as `__Block` when building a block (e.g. `startBlock.js` and `endBlock.js`
- Adds the `NO_KEYS` choice to fixation trial, better matches the other "message" trials

closes #367 