### PR TITLE
ref: Refactor welcome trial

### DIFF
--- a/src/lib/markup/photodiode.js
+++ b/src/lib/markup/photodiode.js
@@ -16,7 +16,6 @@ const photodiodeGhostBox = div(span("", { id: "photodiode-spot" }), { id: "photo
  * Note that this function must be executed inside the "on_load" callback of a trial
  * @param {number} taskCode The unique code for the given trial on which this function executes
  */
-// TODO #355: Conditional check should be at the task level (pass settings here)
 function pdSpotEncode(taskCode) {
   if (!config.USE_ELECTRON) {
     throw new Error("photodiodeSpot trial is only available when running inside Electron");

--- a/src/timelines/honeycombBlock.js
+++ b/src/timelines/honeycombBlock.js
@@ -43,7 +43,6 @@ function buildHoneycombBlock(jsPsych) {
       code: eventCodes.honeycomb,
       correct_response: jsPsych.timelineVariable("correct_response"),
     },
-
     on_load: () => {
       // Conditionally flashes the photodiode when the trial first loads
       if (config.USE_PHOTODIODE) pdSpotEncode(eventCodes.honeycomb);

--- a/src/timelines/startBlock.js
+++ b/src/timelines/startBlock.js
@@ -3,8 +3,9 @@ import { config } from "../config/main";
 import { buildCameraStartTrial } from "../trials/camera";
 import { enterFullscreenTrial } from "../trials/fullscreen";
 import { holdUpMarkerTrial } from "../trials/holdUpMarker";
+import { nameTrial } from "../trials/name";
 import { startCodeTrial } from "../trials/startCode";
-import { nameTrial, welcomeTrial } from "../trials/welcome";
+import { welcomeTrial } from "../trials/welcome";
 
 /**
  * Builds the block of trials needed to start and setup the experiment

--- a/src/timelines/startBlock.js
+++ b/src/timelines/startBlock.js
@@ -5,7 +5,7 @@ import { enterFullscreenTrial } from "../trials/fullscreen";
 import { holdUpMarkerTrial } from "../trials/holdUpMarker";
 import { nameTrial } from "../trials/name";
 import { startCodeTrial } from "../trials/startCode";
-import { welcomeTrial } from "../trials/welcome";
+import { introductionTrial } from "../trials/introduction";
 
 /**
  * Builds the block of trials needed to start and setup the experiment
@@ -19,7 +19,7 @@ import { welcomeTrial } from "../trials/welcome";
  * @returns {Object} A jsPsych (nested) timeline object
  */
 function buildStartBlock(jsPsych) {
-  const startBlock = [nameTrial, enterFullscreenTrial, welcomeTrial];
+  const startBlock = [nameTrial, enterFullscreenTrial, introductionTrial];
 
   // Conditionally add the photodiode setup trials
   if (config.USE_PHOTODIODE) {

--- a/src/trials/holdUpMarker.js
+++ b/src/trials/holdUpMarker.js
@@ -25,7 +25,7 @@ const holdUpMarkerTrial = {
   choices: [LANGUAGE.prompts.continue.button],
   on_load: () => {
     // Conditionally flash the photodiode when the trial first loads
-    if (config.USE_PHOTODIODE) pdSpotEncode(eventCodes.open_task);
+    if (config.USE_PHOTODIODE) pdSpotEncode(eventCodes.test_connect);
   },
 };
 

--- a/src/trials/introduction.js
+++ b/src/trials/introduction.js
@@ -1,29 +1,17 @@
 import htmlKeyboardResponse from "@jspsych/plugin-html-keyboard-response";
 
-import { config, eventCodes, LANGUAGE } from "../config/main";
-import { pdSpotEncode, photodiodeGhostBox } from "../lib/markup/photodiode";
+import { LANGUAGE } from "../config/main";
 import { div, h1 } from "../lib/markup/tags";
 
 /** Task that displays a welcome message with the photodiode ghost box */
 const introductionTrial = {
   type: htmlKeyboardResponse,
+  response_ends_trial: true,
   stimulus: () => {
     const welcomeMarkup = h1(LANGUAGE.trials.welcome);
-    return div(welcomeMarkup, { class: "bottom-prompt" }) + photodiodeGhostBox;
+    return div(welcomeMarkup, { class: "bottom-prompt" });
   },
-  prompt: () => {
-    let promptMarkup = LANGUAGE.prompts.continue.prompt;
-
-    // Conditionally displays the photodiodeGhostBox
-    if (config.USE_PHOTODIODE) promptMarkup += photodiodeGhostBox;
-
-    return promptMarkup;
-  },
-  on_load: () => {
-    // Conditionally flashes the photodiode when the trial first loads
-    if (config.USE_PHOTODIODE) pdSpotEncode(eventCodes.test_connect);
-  },
-  response_ends_trial: true,
+  prompt: LANGUAGE.prompts.continue.prompt,
 };
 
 export { introductionTrial };

--- a/src/trials/introduction.js
+++ b/src/trials/introduction.js
@@ -5,7 +5,7 @@ import { pdSpotEncode, photodiodeGhostBox } from "../lib/markup/photodiode";
 import { div, h1 } from "../lib/markup/tags";
 
 /** Task that displays a welcome message with the photodiode ghost box */
-const welcomeTrial = {
+const introductionTrial = {
   type: htmlKeyboardResponse,
   stimulus: () => {
     const welcomeMarkup = h1(LANGUAGE.trials.welcome);
@@ -26,4 +26,4 @@ const welcomeTrial = {
   response_ends_trial: true,
 };
 
-export { welcomeTrial };
+export { introductionTrial };

--- a/src/trials/name.js
+++ b/src/trials/name.js
@@ -1,0 +1,14 @@
+import htmlKeyboardResponse from "@jspsych/plugin-html-keyboard-response";
+
+import { LANGUAGE } from "../config/main";
+import { h1 } from "../lib/markup/tags";
+
+/** Task that displays the name of the experiment */
+const nameTrial = {
+  type: htmlKeyboardResponse,
+  stimulus: h1(LANGUAGE.name),
+  choices: "NO_KEYS",
+  trial_duration: 1000,
+};
+
+export { nameTrial };

--- a/src/trials/welcome.js
+++ b/src/trials/welcome.js
@@ -4,14 +4,6 @@ import { config, eventCodes, LANGUAGE } from "../config/main";
 import { pdSpotEncode, photodiodeGhostBox } from "../lib/markup/photodiode";
 import { div, h1 } from "../lib/markup/tags";
 
-/** Task that displays the name of the experiment */
-const nameTrial = {
-  type: htmlKeyboardResponse,
-  stimulus: h1(LANGUAGE.name),
-  choices: "NO_KEYS",
-  trial_duration: 1000,
-};
-
 /** Task that displays a welcome message with the photodiode ghost box */
 const welcomeTrial = {
   type: htmlKeyboardResponse,
@@ -34,4 +26,4 @@ const welcomeTrial = {
   response_ends_trial: true,
 };
 
-export { nameTrial, welcomeTrial };
+export { welcomeTrial };


### PR DESCRIPTION
- Renames `welcomeTrial` as `introductionTrial`
- Renames `welcome.js` as `introduction.js`
- Moves `nameTrial` into its own file (`name.js`)
- Removes photodiode encoding from the introduction trial
- `holdUpMarker` trial now sends the `test_connect` event code

closes #231 