### PR TITLE
ref: Use inline exports

### DIFF
--- a/src/App/deployments/firebase.js
+++ b/src/App/deployments/firebase.js
@@ -13,7 +13,7 @@ firebase.initializeApp({
   messagingSenderId: process.env.REACT_APP_messagingSenderId,
   appId: process.env.REACT_APP_appId,
 });
-const db = firebase.firestore();
+export const db = firebase.firestore();
 
 // Use emulator if on localhost
 // TODO #173: Refactor to use NODE_ENV
@@ -21,13 +21,15 @@ if (window.location.hostname === "localhost") db.useEmulator("localhost", 8080);
 
 // Get a reference to the Firebase document at
 // "/participant_responses/{studyID}/participants/{participantID}"
-const getParticipantRef = (studyID, participantID) =>
+function getParticipantRef(studyID, participantID) {
   db.doc(`participant_responses/${studyID}/participants/${participantID}`);
+}
 
 // Get a reference to the Firebase document at
 // "/participant_responses/{studyID}/participants/{participantID}/data/{startDate}"
-const getExperimentRef = (studyID, participantID, startDate) =>
-  db.doc(`${getParticipantRef(studyID, participantID).path}/data/${startDate}`);
+export function getExperimentRef(studyID, participantID, startDate) {
+  return db.doc(`${getParticipantRef(studyID, participantID).path}/data/${startDate}`);
+}
 
 /**
  * Validate the given studyID & participantID combo
@@ -35,7 +37,7 @@ const getExperimentRef = (studyID, participantID, startDate) =>
  * @param {string} participantID The ID of a given participant inside the studyID
  * @returns true if the given studyID & participantID combo is in Firebase, false otherwise
  */
-async function validateParticipant(studyID, participantID) {
+export async function validateParticipant(studyID, participantID) {
   try {
     // .get() will fail on an invalid path
     await getParticipantRef(studyID, participantID).get();
@@ -54,7 +56,7 @@ async function validateParticipant(studyID, participantID) {
  * @param {string} startDate The ID of a given participant inside the studyID and participantID
  * @returns true if able to initialize the new experiment, false otherwise
  */
-async function initParticipant(studyID, participantID, startDate) {
+export async function initParticipant(studyID, participantID, startDate) {
   try {
     const experiment = getExperimentRef(studyID, participantID, startDate);
     await experiment.set({
@@ -78,7 +80,7 @@ async function initParticipant(studyID, participantID, startDate) {
  * Each trial is its own document in the "trials" subcollection
  * @param {any} data The JsPsych data object from a single trial
  */
-async function addToFirebase(data) {
+export async function addToFirebase(data) {
   const studyID = data.study_id;
   const participantID = data.participant_id;
   const startDate = data.start_date;
@@ -90,6 +92,3 @@ async function addToFirebase(data) {
     console.error("Unable to add trial:\n", error);
   }
 }
-
-export { db, getExperimentRef, validateParticipant, initParticipant, addToFirebase };
-export default firebase;

--- a/src/config/main.js
+++ b/src/config/main.js
@@ -9,28 +9,36 @@ import { getProlificId } from "../lib/utils";
 
 import language from "./language.json";
 import settings from "./settings.json";
-import { eventCodes } from "./trigger"; // TODO #333: eventCodes in settings.json
 
 // TODO #363: Separate into index.js (for exporting) and env.js
 
-// Access package name and version so we can store these as facts with task data.
-const taskName = packageInfo.name;
-const taskVersion = packageInfo.version;
+// Re-export the package name and version
+export const taskName = packageInfo.name;
+export const taskVersion = packageInfo.version;
 
-// As of jspsych 7, we instantiate jsPsych where needed instead of importing it globally.
-// The instance here gives access to utils in jsPsych.turk, for awareness of the mturk environment, if any.
-// The actual task and related utils will use a different instance of jsPsych created after login.
-// TODO 370: Initialize using using react code in jsPsychExperiment
+// Re-export the language object
+// TODO #373: Check language in Firebase
+export const LANGUAGE = language;
+// Re-export the settings object
+// TODO #374: Check settings in Firebase
+export const SETTINGS = settings;
+
+/**
+ *
+ * As of jspsych 7, we instantiate jsPsych where needed instead of importing it globally.
+ * The instance here gives access to utils in jsPsych.turk, for awareness of the mturk environment, if any.
+ * The actual task and related utils will use a different instance of jsPsych created after login.
+ * TODO 370: Initialize using using react code in jsPsychExperiment
+ */
 const jsPsych = initJsPsych();
 
 // Whether or not the experiment is running on mechanical turk
 // TODO 370: This is a separate deployment? Should set based on ENV variable
 const turkInfo = jsPsych.turk.turkInfo();
 const USE_MTURK = !turkInfo.outsideTurk;
-const turkUniqueId = `${turkInfo.workerId}:${turkInfo.assignmentId}`; // ID of the user in mechanical turk
+export const turkUniqueId = `${turkInfo.workerId}:${turkInfo.assignmentId}`; // ID of the user in mechanical turk
 
-// Whether or not the experiment is running in Electron (local app)
-const USE_ELECTRON = window.electronAPI !== undefined;
+const USE_ELECTRON = window.electronAPI !== undefined; // Whether or not the experiment is running in Electron (local app)
 const USE_PROLIFIC = (getProlificId() && !USE_MTURK) || false; // Whether or not the experiment is running with Prolific
 const USE_FIREBASE = process.env.REACT_APP_FIREBASE === "true"; // Whether or not the experiment is running in Firebase (web app)
 
@@ -40,10 +48,8 @@ const USE_CAMERA = process.env.REACT_APP_VIDEO === "true" && USE_ELECTRON; // Wh
 const USE_EEG = process.env.REACT_APP_USE_EEG === "true" && USE_ELECTRON; // Whether or not the EEG/event marker is available (TODO: This is only used for sending event codes)
 const USE_PHOTODIODE = process.env.REACT_APP_USE_PHOTODIODE === "true" && USE_ELECTRON; // whether or not the photodiode is in use
 
-/**
- * Configuration object for Honeycomb
- */
-const config = {
+// Configuration object for Honeycomb
+export const config = {
   USE_PHOTODIODE,
   USE_EEG,
   USE_ELECTRON,
@@ -52,15 +58,4 @@ const config = {
   USE_CAMERA,
   USE_PROLIFIC,
   USE_FIREBASE,
-};
-
-/** Export the settings so they can be used anywhere in the app */
-export {
-  language as LANGUAGE, // TODO #373: Check language in Firebase
-  settings as SETTINGS, // TODO #374: Check settings in Firebase
-  config,
-  eventCodes,
-  taskName,
-  taskVersion,
-  turkUniqueId,
 };

--- a/src/config/trigger.js
+++ b/src/config/trigger.js
@@ -1,21 +1,20 @@
 // TODO #333: Move to "event_marker" config.json
 
 // teensyduino
-const vendorID = "16c0";
+export const vendorID = "16c0";
 
 // Default if process.env.EVENT_MARKER_PRODUCT_ID is not set
-const productID = process.env.EVENT_MARKER_PRODUCT_ID || "";
+export const productID = process.env.EVENT_MARKER_PRODUCT_ID || "";
 
 // Default if process.env.EVENT_MARKER_COM_NAME is not set
-const comName = process.env.EVENT_MARKER_COM_NAME || "COM3";
+export const comName = process.env.EVENT_MARKER_COM_NAME || "COM3";
 
 /** Custom codes for specific task events - used to identify the trials */
 // TODO #354: Each event should have a code, name, and numBlinks
-const eventCodes = {
+// TODO #333: eventCodes in settings.json
+export const eventCodes = {
   fixation: 1, // Fixation trial
   honeycomb: 2, // Main reaction-time trial for the Honeycomb task
   open_task: 18, // Opening task for setting up the experiment
   test_connect: 32, // Initial test connection
 };
-
-export { vendorID, productID, comName, eventCodes };

--- a/src/experiment/blocks/endBlock.js
+++ b/src/experiment/blocks/endBlock.js
@@ -11,7 +11,7 @@ import { exitFullscreenTrial } from "../trials/fullscreen";
  * @param {Object} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych (nested) timeline object
  */
-function buildEndBlock(jsPsych) {
+export function buildEndBlock(jsPsych) {
   const endBlock = [];
 
   // Conditionally add the camera breakdown trials
@@ -25,5 +25,3 @@ function buildEndBlock(jsPsych) {
   // Return the block as a nested timeline
   return { timeline: endBlock };
 }
-
-export { buildEndBlock };

--- a/src/experiment/blocks/honeycombBlock.js
+++ b/src/experiment/blocks/honeycombBlock.js
@@ -15,7 +15,7 @@ import { buildFixationTrial } from "../trials/fixation";
  * @param {Object} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych (nested) timeline object
  */
-function buildHoneycombBlock(jsPsych) {
+export function buildHoneycombBlock(jsPsych) {
   const honeycombSettings = SETTINGS.honeycomb;
 
   const fixationTrial = buildFixationTrial(jsPsych);
@@ -71,5 +71,3 @@ function buildHoneycombBlock(jsPsych) {
   };
   return honeycombBlock;
 }
-
-export { buildHoneycombBlock };

--- a/src/experiment/blocks/honeycombBlock.js
+++ b/src/experiment/blocks/honeycombBlock.js
@@ -1,7 +1,8 @@
 import imageKeyboardResponse from "@jspsych/plugin-image-keyboard-response";
 
-import { config, eventCodes, SETTINGS } from "../../config/main";
-import { photodiodeGhostBox, pdSpotEncode } from "../../lib/markup/photodiode";
+import { config, SETTINGS } from "../../config/main";
+import { eventCodes } from "../../config/trigger";
+import { pdSpotEncode, photodiodeGhostBox } from "../../lib/markup/photodiode";
 import { buildFixationTrial } from "../trials/fixation";
 
 /**

--- a/src/experiment/blocks/startBlock.js
+++ b/src/experiment/blocks/startBlock.js
@@ -18,7 +18,7 @@ import { introductionTrial } from "../trials/introduction";
  * @param {Object} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych (nested) timeline object
  */
-function buildStartBlock(jsPsych) {
+export function buildStartBlock(jsPsych) {
   const startBlock = [nameTrial, enterFullscreenTrial, introductionTrial];
 
   // Conditionally add the photodiode setup trials
@@ -35,5 +35,3 @@ function buildStartBlock(jsPsych) {
   // Return the block as a nested timeline
   return { timeline: startBlock };
 }
-
-export { buildStartBlock };

--- a/src/experiment/honeycomb.js
+++ b/src/experiment/honeycomb.js
@@ -13,7 +13,7 @@ import { buildDebriefTrial, instructionsTrial, preloadTrial } from "./trials/hon
  * Experiment-wide settings for jsPsych: https://www.jspsych.org/7.3/overview/experiment-options/
  * Note that Honeycomb combines these with other options required for Honeycomb to operate correctly
  */
-const honeycombOptions = {
+export const honeycombOptions = {
   on_finish: (data) => console.log("The experiment has finished:", data),
 };
 
@@ -25,7 +25,7 @@ const honeycombOptions = {
  * @param {Object} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych timeline object
  */
-function buildHoneycombTimeline(jsPsych) {
+export function buildHoneycombTimeline(jsPsych) {
   // Build the trials that make up the start block
   const startBlock = buildStartBlock(jsPsych);
 
@@ -48,5 +48,3 @@ function buildHoneycombTimeline(jsPsych) {
   ];
   return timeline;
 }
-
-export { buildHoneycombTimeline, honeycombOptions };

--- a/src/experiment/index.js
+++ b/src/experiment/index.js
@@ -15,7 +15,7 @@ import "../lib/markup/trials.css";
  *
  * Custom options for your experiment should be added in your own file inside the experiment folder
  */
-const jsPsychOptions = {
+export const jsPsychOptions = {
   ...honeycombOptions,
   on_trial_finish: (data) => console.log(`Trial ${data.internal_node_id} just finished:`, data),
 };
@@ -28,7 +28,7 @@ const jsPsychOptions = {
  * @param {string} participantID The ID of the participant that was just logged in
  * @returns The timeline for JsPsych to run
  */
-function buildTimeline(jsPsych, studyID, participantID) {
+export function buildTimeline(jsPsych, studyID, participantID) {
   console.log(`Building timeline for participant ${participantID} on study ${studyID}`);
 
   /**
@@ -39,5 +39,3 @@ function buildTimeline(jsPsych, studyID, participantID) {
 
   return timeline;
 }
-
-export { buildTimeline, jsPsychOptions };

--- a/src/experiment/trials/adjustVolume.js
+++ b/src/experiment/trials/adjustVolume.js
@@ -3,7 +3,7 @@ import { LANGUAGE } from "../../config/main";
 import { div, h1 } from "../../lib/markup/tags";
 
 /** Trial that prompts the user to adjust the volume on their computer */
-const adjustVolumeTrial = {
+export const adjustVolumeTrial = {
   type: htmlKeyboardResponse,
   stimulus: () => {
     const adjustVolumeMarkup = h1(LANGUAGE.trials.adjustVolume);
@@ -12,5 +12,3 @@ const adjustVolumeTrial = {
   prompt: LANGUAGE.prompts.continue.prompt,
   response_ends_trial: true,
 };
-
-export { adjustVolumeTrial };

--- a/src/experiment/trials/camera.js
+++ b/src/experiment/trials/camera.js
@@ -11,7 +11,7 @@ import { div, h1, p, tag } from "../../lib/markup/tags";
  * @returns {Object} A jsPsych trial object
  */
 // TODO #342: refactor to record using web USB
-function buildCameraStartTrial(jsPsych) {
+export function buildCameraStartTrial(jsPsych) {
   return {
     timeline: [
       {
@@ -90,7 +90,7 @@ function buildCameraStartTrial(jsPsych) {
  * @param {Number} duration How long to show the trial for
  * @returns {Object} A jsPsych trial object
  */
-function buildCameraEndTrial(jsPsych) {
+export function buildCameraEndTrial(jsPsych) {
   const recordingEndMarkup = h1(LANGUAGE.trials.camera.end);
 
   return {
@@ -115,5 +115,3 @@ function buildCameraEndTrial(jsPsych) {
     },
   };
 }
-
-export { buildCameraStartTrial, buildCameraEndTrial };

--- a/src/experiment/trials/conclusion.js
+++ b/src/experiment/trials/conclusion.js
@@ -4,11 +4,9 @@ import { LANGUAGE } from "../../config/main";
 import { h1 } from "../../lib/markup/tags";
 
 /** Trial that displays a completion message for 5 seconds */
-const conclusionTrial = {
+export const conclusionTrial = {
   type: htmlKeyboardResponse,
   stimulus: h1(LANGUAGE.trials.conclusion),
   choices: "NO_KEYS",
   trial_duration: 5000,
 };
-
-export { conclusionTrial };

--- a/src/experiment/trials/fixation.js
+++ b/src/experiment/trials/fixation.js
@@ -11,7 +11,6 @@ import { div } from "../../lib/markup/tags";
  * @returns {Object} A jsPsych trial object
  */
 export function buildFixationTrial(jsPsych) {
-  // TODO #371: These settings should be passed as a parameter to the function
   const fixationSettings = SETTINGS.fixation;
   const fixationCode = eventCodes.fixation;
 

--- a/src/experiment/trials/fixation.js
+++ b/src/experiment/trials/fixation.js
@@ -1,6 +1,7 @@
 import htmlKeyboardResponse from "@jspsych/plugin-html-keyboard-response";
 
-import { SETTINGS, config, eventCodes } from "../../config/main";
+import { SETTINGS, config } from "../../config/main";
+import { eventCodes } from "../../config/trigger";
 import { pdSpotEncode, photodiodeGhostBox } from "../../lib/markup/photodiode";
 import { div } from "../../lib/markup/tags";
 

--- a/src/experiment/trials/holdUpMarker.js
+++ b/src/experiment/trials/holdUpMarker.js
@@ -7,7 +7,7 @@ import { div, h1, p } from "../../lib/markup/tags";
 
 // TODO #330: Rename as checkEEG? (this is a similar trial to cameraStart)
 // TODO #330: Actually check to see if USB is connected? This isn't testing anything?
-const holdUpMarkerTrial = {
+export const holdUpMarkerTrial = {
   type: htmlButtonResponse,
   stimulus: () => {
     const eventMarkerMarkup = h1(LANGUAGE.trials.eventMarker.connected, {
@@ -29,5 +29,3 @@ const holdUpMarkerTrial = {
     if (config.USE_PHOTODIODE) pdSpotEncode(eventCodes.test_connect);
   },
 };
-
-export { holdUpMarkerTrial };

--- a/src/experiment/trials/holdUpMarker.js
+++ b/src/experiment/trials/holdUpMarker.js
@@ -1,6 +1,7 @@
 import htmlButtonResponse from "@jspsych/plugin-html-button-response";
 
-import { config, eventCodes, LANGUAGE } from "../../config/main";
+import { config, LANGUAGE } from "../../config/main";
+import { eventCodes } from "../../config/trigger";
 import { pdSpotEncode, photodiodeGhostBox } from "../../lib/markup/photodiode";
 import { div, h1, p } from "../../lib/markup/tags";
 

--- a/src/experiment/trials/honeycombTrials.js
+++ b/src/experiment/trials/honeycombTrials.js
@@ -15,7 +15,7 @@ const honeycombLanguage = LANGUAGE.trials.honeycomb;
  * Instructions have been altered from the original tutorial to match the instructions plugin:
  * https://www.jspsych.org/7.3/plugins/instructions/#including-images
  */
-const instructionsTrial = {
+export const instructionsTrial = {
   type: instructionsResponse,
   pages: [
     p(honeycombLanguage.instructions.read),
@@ -44,7 +44,7 @@ const instructionsTrial = {
 };
 
 /** Trial that loads all of the stimulus images */
-const preloadTrial = {
+export const preloadTrial = {
   type: preloadResponse,
   message: p(LANGUAGE.prompts.settingUp),
   images: SETTINGS.honeycomb.timeline_variables.map(({ stimulus }) => stimulus),
@@ -52,7 +52,7 @@ const preloadTrial = {
 // TODO #281: Function for preloading all files in public/images?
 
 /** Trial that calculates and displays some results of the session  */
-function buildDebriefTrial(jsPsych) {
+export function buildDebriefTrial(jsPsych) {
   return {
     type: htmlKeyboardResponse,
     stimulus: () => {
@@ -80,5 +80,3 @@ function buildDebriefTrial(jsPsych) {
     },
   };
 }
-
-export { buildDebriefTrial, instructionsTrial, preloadTrial };

--- a/src/experiment/trials/honeycombTrials.js
+++ b/src/experiment/trials/honeycombTrials.js
@@ -2,7 +2,8 @@ import htmlKeyboardResponse from "@jspsych/plugin-html-keyboard-response";
 import instructionsResponse from "@jspsych/plugin-instructions";
 import preloadResponse from "@jspsych/plugin-preload";
 
-import { eventCodes, LANGUAGE, SETTINGS } from "../../config/main";
+import { LANGUAGE, SETTINGS } from "../../config/main";
+import { eventCodes } from "../../config/trigger";
 import { b, div, image, p } from "../../lib/markup/tags";
 
 const honeycombLanguage = LANGUAGE.trials.honeycomb;

--- a/src/experiment/trials/introduction.js
+++ b/src/experiment/trials/introduction.js
@@ -4,7 +4,7 @@ import { LANGUAGE } from "../../config/main";
 import { div, h1 } from "../../lib/markup/tags";
 
 /** Task that displays a welcome message with the photodiode ghost box */
-const introductionTrial = {
+export const introductionTrial = {
   type: htmlKeyboardResponse,
   response_ends_trial: true,
   stimulus: () => {
@@ -13,5 +13,3 @@ const introductionTrial = {
   },
   prompt: LANGUAGE.prompts.continue.prompt,
 };
-
-export { introductionTrial };

--- a/src/experiment/trials/name.js
+++ b/src/experiment/trials/name.js
@@ -4,11 +4,9 @@ import { LANGUAGE } from "../../config/main";
 import { h1 } from "../../lib/markup/tags";
 
 /** Task that displays the name of the experiment */
-const nameTrial = {
+export const nameTrial = {
   type: htmlKeyboardResponse,
   stimulus: h1(LANGUAGE.name),
   choices: "NO_KEYS",
   trial_duration: 1000,
 };
-
-export { nameTrial };

--- a/src/experiment/trials/startCode.js
+++ b/src/experiment/trials/startCode.js
@@ -8,7 +8,7 @@ import { h1 } from "../../lib/markup/tags";
 // TODO #364: Refactor to use JsPsych audio trial
 // TODO #364: Remove "USE_VOLUME"
 // TODO #364: "Setting up" is a separate trial that runs ALL of the needed setup
-const startCodeTrial = {
+export const startCodeTrial = {
   type: audioKeyboardResponse,
   stimulus: "assets/audio/beep.mp3",
   choices: "NO_KEYS",
@@ -24,5 +24,3 @@ const startCodeTrial = {
     if (config.USE_PHOTODIODE) pdSpotEncode(eventCodes.open_task);
   },
 };
-
-export { startCodeTrial };

--- a/src/experiment/trials/startCode.js
+++ b/src/experiment/trials/startCode.js
@@ -1,6 +1,7 @@
 import audioKeyboardResponse from "@jspsych/plugin-audio-keyboard-response";
 
-import { config, eventCodes, LANGUAGE } from "../../config/main";
+import { config, LANGUAGE } from "../../config/main";
+import { eventCodes } from "../../config/trigger";
 import { pdSpotEncode, photodiodeGhostBox } from "../../lib/markup/photodiode";
 import { h1 } from "../../lib/markup/tags";
 

--- a/src/experiment/trials/survey.js
+++ b/src/experiment/trials/survey.js
@@ -10,7 +10,7 @@ const demographicsSurveyLanguage = LANGUAGE.trials.survey.demographics;
  * Displays a survey for the participant to complete.
  * Demographic data about the participant is collected
  */
-const demographicsSurvey = {
+export const demographicsSurvey = {
   type: jsPsychSurveyPlugin,
   title: demographicsSurveyLanguage.title,
   pages: [
@@ -70,7 +70,7 @@ const iusSurveyLanguage = LANGUAGE.trials.survey.ius;
  * Displays a survey designed to measure intolerance of uncertainty.
  * The user is shown multiple questions across a likert scale
  */
-const iusSurvey = {
+export const iusSurvey = {
   type: jsPsychSurveyPlugin,
   title: iusSurveyLanguage.title,
   pages: [
@@ -85,5 +85,3 @@ const iusSurvey = {
     ],
   ],
 };
-
-export { demographicsSurvey, iusSurvey };

--- a/src/lib/markup/photodiode.js
+++ b/src/lib/markup/photodiode.js
@@ -8,7 +8,9 @@ import { div, span } from "./tags";
  * Note the box will only be visible if USE_PHOTODIODE is true
  * Note that this trial is only available when running in Electron
  */
-const photodiodeGhostBox = div(span("", { id: "photodiode-spot" }), { id: "photodiode-box" });
+export const photodiodeGhostBox = div(span("", { id: "photodiode-spot" }), {
+  id: "photodiode-box",
+});
 
 /**
  * Conditionally flashes a spot inside the photodiodeGhostBox and sends event codes to the serial port
@@ -16,7 +18,7 @@ const photodiodeGhostBox = div(span("", { id: "photodiode-spot" }), { id: "photo
  * Note that this function must be executed inside the "on_load" callback of a trial
  * @param {number} taskCode The unique code for the given trial on which this function executes
  */
-function pdSpotEncode(taskCode) {
+export function pdSpotEncode(taskCode) {
   if (!config.USE_ELECTRON) {
     throw new Error("photodiodeSpot trial is only available when running inside Electron");
   }
@@ -57,5 +59,3 @@ function pdSpotEncode(taskCode) {
     }
   }
 }
-
-export { photodiodeGhostBox, pdSpotEncode };

--- a/src/lib/markup/tags.js
+++ b/src/lib/markup/tags.js
@@ -10,7 +10,7 @@
  * @param {object} attributes HTML attributes to add to the tag
  * @returns {string} A string containing static HTML
  */
-function tag(tag, children, attributes = {}) {
+export function tag(tag, children, attributes = {}) {
   let attributesString;
   if (Object.keys(attributes).length === 0) {
     // No attributes
@@ -32,14 +32,14 @@ function tag(tag, children, attributes = {}) {
  * @param {object} attributes HTML attributes to add to the tag
  * @returns {string} A string containing static HTML
  */
-function b(children, attributes = {}) {
+export function b(children, attributes = {}) {
   return tag("b", children, attributes);
 }
 
 /**
  * Returns a break tag
  */
-function br() {
+export function br() {
   return "<br />";
 }
 
@@ -49,7 +49,7 @@ function br() {
  * @param {object} attributes HTML attributes to add to the tag
  * @returns {string} A string containing static HTML
  */
-function div(children, attributes = {}) {
+export function div(children, attributes = {}) {
   return tag("div", children, attributes);
 }
 
@@ -59,7 +59,7 @@ function div(children, attributes = {}) {
  * @param {object} attributes HTML attributes to add to the tag
  * @returns {string} A string containing static HTML
  */
-function h1(children, attributes = {}) {
+export function h1(children, attributes = {}) {
   return tag("h1", children, attributes);
 }
 
@@ -69,7 +69,7 @@ function h1(children, attributes = {}) {
  * @param {object} attributes HTML attributes to add to the tag
  * @returns {string} A string containing static HTML
  */
-function i(children, attributes = {}) {
+export function i(children, attributes = {}) {
   return tag("i", children, attributes);
 }
 
@@ -78,7 +78,7 @@ function i(children, attributes = {}) {
  * @param {object} attributes HTML attributes to add to the tag
  * @returns {string} A string containing static HTML
  */
-function image(attributes = {}) {
+export function image(attributes = {}) {
   return tag("img", "", attributes);
 }
 
@@ -88,7 +88,7 @@ function image(attributes = {}) {
  * @param {object} attributes HTML attributes to add to the tag
  * @returns {string} A string containing static HTML
  */
-function p(children, attributes = {}) {
+export function p(children, attributes = {}) {
   return tag("p", children, attributes);
 }
 
@@ -98,8 +98,6 @@ function p(children, attributes = {}) {
  * @param {object} attributes HTML attributes to add to the tag
  * @returns {string} A string containing static HTML
  */
-function span(children, attributes = {}) {
+export function span(children, attributes = {}) {
   return tag("span", children, attributes);
 }
-
-export { b, br, div, h1, i, image, p, span, tag };

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -3,7 +3,7 @@
  * @param {number} ms The number of milliseconds to sleep for
  * @returns A resolved promise after ms milliseconds
  */
-function sleep(ms) {
+export function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
@@ -13,7 +13,7 @@ function sleep(ms) {
  * @param {number} offset The maximum addition to base
  * @returns The base number jittered by the offset
  */
-function jitter(base, offset) {
+export function jitter(base, offset) {
   return base + Math.floor(Math.random() * Math.floor(offset));
 }
 
@@ -22,7 +22,7 @@ function jitter(base, offset) {
  * @param {number} base The starting number
  * @returns The base number jittered by 50
  */
-function jitter50(base) {
+export function jitter50(base) {
   return jitter(base, 50);
 }
 
@@ -30,7 +30,7 @@ function jitter50(base) {
  * Flips a coin
  * @returns Returns true or false randomly
  */
-function randomTrue() {
+export function randomTrue() {
   return Math.random() > 0.5;
 }
 
@@ -39,7 +39,7 @@ function randomTrue() {
  * @param {Object} obj The starting object
  * @returns An exact copy of obj
  */
-function deepCopy(obj) {
+export function deepCopy(obj) {
   return JSON.parse(JSON.stringify(obj));
 }
 
@@ -48,7 +48,7 @@ function deepCopy(obj) {
  * @param {number} amount Dollar amount
  * @returns The string representation of amount in USD
  */
-function formatDollars(amount) {
+export function formatDollars(amount) {
   return "$" + parseFloat(amount).toFixed(2);
 }
 
@@ -56,7 +56,7 @@ function formatDollars(amount) {
  * Starts the JsPsych keyboard response listener
  * @param  jsPsych The jsPsych instance running the task.
  */
-function startKeypressListener(jsPsych) {
+export function startKeypressListener(jsPsych) {
   const keypressResponse = (info) => {
     const data = { key_press: info.key };
     jsPsych.finishTrial(data);
@@ -76,7 +76,7 @@ function startKeypressListener(jsPsych) {
  * @param {string} queryParameter The key of the variable in the search parameters
  * @returns {string} The value of variable in the search parameters
  */
-function getSearchParam(queryParameter) {
+export function getSearchParam(queryParameter) {
   const params = new URLSearchParams(window.location.search);
   return params.get(queryParameter);
 }
@@ -85,7 +85,7 @@ function getSearchParam(queryParameter) {
  * Gets the ID of a prolific user from the URL search parameters
  * @returns
  */
-function getProlificId() {
+export function getProlificId() {
   const prolificId = getSearchParam("PROLIFIC_PID");
   return prolificId;
 }
@@ -97,19 +97,6 @@ function getProlificId() {
  * @param {boolean} addBefore Whether to add val before or after each element in array
  * @returns The original array with val interleaved between every element
  */
-function interleave(arr, val, addBefore = true) {
+export function interleave(arr, val, addBefore = true) {
   return [].concat(...arr.map((n) => (addBefore ? [val, n] : [n, val])));
 }
-
-export {
-  deepCopy,
-  formatDollars,
-  getProlificId,
-  getSearchParam,
-  interleave,
-  jitter,
-  jitter50,
-  randomTrue,
-  sleep,
-  startKeypressListener,
-};


### PR DESCRIPTION
- Use inline exports instead of an export block at the bottom of the file
- Removes the re-export of `eventCodes` from `main.js`

closes #200 