### PR TITLE
ref: Prefer `function(){}` instead of arrow functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -141,20 +141,20 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.23.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.7.tgz",
-      "integrity": "sha512-+UpDgowcmqe36d4NwqvKsyPMlOLNGMsfMmQ5WGCu+siCe3t3dfe9njrzGfdN4qq+bcNUt0+Vw6haRxBOycs4dw==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.9.tgz",
+      "integrity": "sha512-5q0175NOjddqpvvzU+kDiSOAk4PfdO6FvwCWoQ6RO7rTzEe8vlo+4HVfcnAREhD4npMs0e9uZypjTwzZPCf/cw==",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.23.5",
         "@babel/generator": "^7.23.6",
         "@babel/helper-compilation-targets": "^7.23.6",
         "@babel/helper-module-transforms": "^7.23.3",
-        "@babel/helpers": "^7.23.7",
-        "@babel/parser": "^7.23.6",
-        "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.7",
-        "@babel/types": "^7.23.6",
+        "@babel/helpers": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@babel/template": "^7.23.9",
+        "@babel/traverse": "^7.23.9",
+        "@babel/types": "^7.23.9",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -170,9 +170,9 @@
       }
     },
     "node_modules/@babel/eslint-parser": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.23.3.tgz",
-      "integrity": "sha512-9bTuNlyx7oSstodm1cR1bECj4fkiknsDa1YniISkJemMY3DGhJNYBECbe6QD/q54mp2J8VO66jW3/7uP//iFCw==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.23.9.tgz",
+      "integrity": "sha512-xPndlO7qxiJbn0ATvfXQBjCS7qApc9xmKHArgI/FTEFxXas5dnjC/VqM37lfZun9dclRYcn+YQAr6uDFy0bB2g==",
       "dependencies": {
         "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
         "eslint-visitor-keys": "^2.1.0",
@@ -246,9 +246,9 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.23.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.7.tgz",
-      "integrity": "sha512-xCoqR/8+BoNnXOY7RVSgv6X+o7pmT5q1d+gGcRlXYkI+9B31glE4jeejhKVpA04O1AtzOt7OSQ6VYKP5FcRl9g==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.9.tgz",
+      "integrity": "sha512-B2L9neXTIyPQoXDm+NtovPvG6VOLWnaXu3BIeVDWwdKFgG30oNa6CqVGiJPDWQwIAK49t9gnQI9c6K6RzabiKw==",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
         "@babel/helper-environment-visitor": "^7.22.20",
@@ -284,9 +284,9 @@
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.4.tgz",
-      "integrity": "sha512-QcJMILQCu2jm5TFPGA3lCpJJTeEP+mqeXooG/NZbg/h5FTFi6V0+99ahlRsW8/kRLyb24LZVCCiclDedhLKcBA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.5.0.tgz",
+      "integrity": "sha512-NovQquuQLAQ5HuyjCz7WQP9MjRj7dx++yspwiyUiGl9ZyadHRSql1HZh5ogRd8W8w6YM6EQ/NTB8rgjLt5W65Q==",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.22.6",
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -491,13 +491,13 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.23.8",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.8.tgz",
-      "integrity": "sha512-KDqYz4PiOWvDFrdHLPhKtCThtIcKVy6avWD2oG4GEvyQ+XDZwHD4YQd+H2vNMnq2rkdxsDkU82T+Vk8U/WXHRQ==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.9.tgz",
+      "integrity": "sha512-87ICKgU5t5SzOT7sBMfCOZQ2rHjRU+Pcb9BoILMYz600W6DkVRLFBPwQ18gwUVvggqXivaUakpnxWQGbpywbBQ==",
       "dependencies": {
-        "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.7",
-        "@babel/types": "^7.23.6"
+        "@babel/template": "^7.23.9",
+        "@babel/traverse": "^7.23.9",
+        "@babel/types": "^7.23.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -517,9 +517,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
-      "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.9.tgz",
+      "integrity": "sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -589,11 +589,11 @@
       }
     },
     "node_modules/@babel/plugin-proposal-decorators": {
-      "version": "7.23.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.23.7.tgz",
-      "integrity": "sha512-b1s5JyeMvqj7d9m9KhJNHKc18gEJiSyVzVX3bwbiPalQBQpuvfPh6lA9F7Kk/dWH0TIiXRpB9yicwijY6buPng==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.23.9.tgz",
+      "integrity": "sha512-hJhBCb0+NnTWybvWq2WpbCYDOcflSbx0t+BYP65e5R9GVnukiDTi+on5bFkk4p7QGuv190H6KfNiV9Knf/3cZA==",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.23.7",
+        "@babel/helper-create-class-features-plugin": "^7.23.9",
         "@babel/helper-plugin-utils": "^7.22.5",
         "@babel/plugin-syntax-decorators": "^7.23.3"
       },
@@ -987,9 +987,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-generator-functions": {
-      "version": "7.23.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.7.tgz",
-      "integrity": "sha512-PdxEpL71bJp1byMG0va5gwQcXHxuEYC/BgI/e88mGTtohbZN28O5Yit0Plkkm/dBzCF/BxmbNcses1RH1T+urA==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.9.tgz",
+      "integrity": "sha512-8Q3veQEDGe14dTYuwagbRtwxQDnytyg1JFu4/HwEMETeofocrB0U0ejBJIXoeG/t2oXZ8kzCyI0ZZfbT80VFNQ==",
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -1338,9 +1338,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.23.3.tgz",
-      "integrity": "sha512-ZxyKGTkF9xT9YJuKQRo19ewf3pXpopuYQd8cDXqNzc3mUNbOME0RKMoZxviQk74hwzfQsEe66dE92MaZbdHKNQ==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.23.9.tgz",
+      "integrity": "sha512-KDlPRM6sLo4o1FkiSlXoAa8edLXFsKKIda779fbLrvmeuc3itnjCtaO6RrtoaANsIJANj+Vk1zqbZIMhkCAHVw==",
       "dependencies": {
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-module-transforms": "^7.23.3",
@@ -1657,15 +1657,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime": {
-      "version": "7.23.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.7.tgz",
-      "integrity": "sha512-fa0hnfmiXc9fq/weK34MUV0drz2pOL/vfKWvN7Qw127hiUPabFCUMgAbYWcchRzMJit4o5ARsK/s+5h0249pLw==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.9.tgz",
+      "integrity": "sha512-A7clW3a0aSjm3ONU9o2HAILSegJCYlEZmOhmBRReVtIpY/Z/p7yIZ+wR41Z+UipwdGuqwtID/V/dOdZXjwi9gQ==",
       "dependencies": {
         "@babel/helper-module-imports": "^7.22.15",
         "@babel/helper-plugin-utils": "^7.22.5",
-        "babel-plugin-polyfill-corejs2": "^0.4.7",
-        "babel-plugin-polyfill-corejs3": "^0.8.7",
-        "babel-plugin-polyfill-regenerator": "^0.5.4",
+        "babel-plugin-polyfill-corejs2": "^0.4.8",
+        "babel-plugin-polyfill-corejs3": "^0.9.0",
+        "babel-plugin-polyfill-regenerator": "^0.5.5",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -1823,9 +1823,9 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.23.8",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.8.tgz",
-      "integrity": "sha512-lFlpmkApLkEP6woIKprO6DO60RImpatTQKtz4sUcDjVcK8M8mQ4sZsuxaTMNOZf0sqAq/ReYW1ZBHnOQwKpLWA==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.9.tgz",
+      "integrity": "sha512-3kBGTNBBk9DQiPoXYS0g0BYlwTQYUTifqgKTjxUwEUkduRT2QOa0FPGBJ+NROQhGyYO5BuTJwGvBnqKDykac6A==",
       "dependencies": {
         "@babel/compat-data": "^7.23.5",
         "@babel/helper-compilation-targets": "^7.23.6",
@@ -1854,7 +1854,7 @@
         "@babel/plugin-syntax-top-level-await": "^7.14.5",
         "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
         "@babel/plugin-transform-arrow-functions": "^7.23.3",
-        "@babel/plugin-transform-async-generator-functions": "^7.23.7",
+        "@babel/plugin-transform-async-generator-functions": "^7.23.9",
         "@babel/plugin-transform-async-to-generator": "^7.23.3",
         "@babel/plugin-transform-block-scoped-functions": "^7.23.3",
         "@babel/plugin-transform-block-scoping": "^7.23.4",
@@ -1876,7 +1876,7 @@
         "@babel/plugin-transform-member-expression-literals": "^7.23.3",
         "@babel/plugin-transform-modules-amd": "^7.23.3",
         "@babel/plugin-transform-modules-commonjs": "^7.23.3",
-        "@babel/plugin-transform-modules-systemjs": "^7.23.3",
+        "@babel/plugin-transform-modules-systemjs": "^7.23.9",
         "@babel/plugin-transform-modules-umd": "^7.23.3",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.22.5",
         "@babel/plugin-transform-new-target": "^7.23.3",
@@ -1902,9 +1902,9 @@
         "@babel/plugin-transform-unicode-regex": "^7.23.3",
         "@babel/plugin-transform-unicode-sets-regex": "^7.23.3",
         "@babel/preset-modules": "0.1.6-no-external-plugins",
-        "babel-plugin-polyfill-corejs2": "^0.4.7",
-        "babel-plugin-polyfill-corejs3": "^0.8.7",
-        "babel-plugin-polyfill-regenerator": "^0.5.4",
+        "babel-plugin-polyfill-corejs2": "^0.4.8",
+        "babel-plugin-polyfill-corejs3": "^0.9.0",
+        "babel-plugin-polyfill-regenerator": "^0.5.5",
         "core-js-compat": "^3.31.0",
         "semver": "^6.3.1"
       },
@@ -1982,9 +1982,9 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "node_modules/@babel/runtime": {
-      "version": "7.23.8",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.8.tgz",
-      "integrity": "sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
+      "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -1993,22 +1993,22 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.23.9.tgz",
+      "integrity": "sha512-+xrD2BWLpvHKNmX2QbpdpsBaWnRxahMwJjO+KZk2JOElj5nSmKezyS1B4u+QbHMTX69t4ukm6hh9lsYQ7GHCKA==",
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/code-frame": "^7.23.5",
+        "@babel/parser": "^7.23.9",
+        "@babel/types": "^7.23.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.7.tgz",
-      "integrity": "sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.9.tgz",
+      "integrity": "sha512-I/4UJ9vs90OkBtY6iiiTORVMyIhJ4kAVmsKo9KFc8UOxMeUfi2hvtIBsET5u9GizXE6/GFSuKCTNfgCswuEjRg==",
       "dependencies": {
         "@babel/code-frame": "^7.23.5",
         "@babel/generator": "^7.23.6",
@@ -2016,8 +2016,8 @@
         "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.6",
-        "@babel/types": "^7.23.6",
+        "@babel/parser": "^7.23.9",
+        "@babel/types": "^7.23.9",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -2026,9 +2026,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
-      "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.9.tgz",
+      "integrity": "sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==",
       "dependencies": {
         "@babel/helper-string-parser": "^7.23.4",
         "@babel/helper-validator-identifier": "^7.22.20",
@@ -2054,13 +2054,13 @@
       }
     },
     "node_modules/@commitlint/config-validator": {
-      "version": "18.4.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-18.4.4.tgz",
-      "integrity": "sha512-/QI8KIg/h7O0Eus36fPcEcO3QPBcdXuGfZeCF5m15k0EB2bcU8s6pHNTNEa6xz9PrAefHCL+yzRJj7w20T6Mow==",
+      "version": "18.6.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-18.6.0.tgz",
+      "integrity": "sha512-Ptfa865arNozlkjxrYG3qt6wT9AlhNUHeuDyKEZiTL/l0ftncFhK/KN0t/EAMV2tec+0Mwxo0FmhbESj/bI+1g==",
       "dev": true,
       "optional": true,
       "dependencies": {
-        "@commitlint/types": "^18.4.4",
+        "@commitlint/types": "^18.6.0",
         "ajv": "^8.11.0"
       },
       "engines": {
@@ -2078,16 +2078,16 @@
       }
     },
     "node_modules/@commitlint/load": {
-      "version": "18.4.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-18.4.4.tgz",
-      "integrity": "sha512-RaDIa9qwOw2xRJ3Jr2DBXd14rmnHJIX2XdZF4kmoF1rgsg/+7cvrExLSUNAkQUNimyjCn1b/bKX2Omm+GdY0XQ==",
+      "version": "18.6.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-18.6.0.tgz",
+      "integrity": "sha512-RRssj7TmzT0bowoEKlgwg8uQ7ORXWkw7lYLsZZBMi9aInsJuGNLNWcMxJxRZbwxG3jkCidGUg85WmqJvRjsaDA==",
       "dev": true,
       "optional": true,
       "dependencies": {
-        "@commitlint/config-validator": "^18.4.4",
+        "@commitlint/config-validator": "^18.6.0",
         "@commitlint/execute-rule": "^18.4.4",
-        "@commitlint/resolve-extends": "^18.4.4",
-        "@commitlint/types": "^18.4.4",
+        "@commitlint/resolve-extends": "^18.6.0",
+        "@commitlint/types": "^18.6.0",
         "chalk": "^4.1.0",
         "cosmiconfig": "^8.3.6",
         "cosmiconfig-typescript-loader": "^5.0.0",
@@ -2177,14 +2177,14 @@
       }
     },
     "node_modules/@commitlint/resolve-extends": {
-      "version": "18.4.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-18.4.4.tgz",
-      "integrity": "sha512-RRpIHSbRnFvmGifVk21Gqazf1QF/yeP+Kkg/e3PlkegcOKd/FGOXp/Kx9cvSO2K7ucSn4GD/oBvgasFoy+NCAw==",
+      "version": "18.6.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-18.6.0.tgz",
+      "integrity": "sha512-k2Xp+Fxeggki2i90vGrbiLDMefPius3zGSTFFlRAPKce/SWLbZtI+uqE9Mne23mHO5lmcSV8z5m6ziiJwGpOcg==",
       "dev": true,
       "optional": true,
       "dependencies": {
-        "@commitlint/config-validator": "^18.4.4",
-        "@commitlint/types": "^18.4.4",
+        "@commitlint/config-validator": "^18.6.0",
+        "@commitlint/types": "^18.6.0",
         "import-fresh": "^3.0.0",
         "lodash.mergewith": "^4.6.2",
         "resolve-from": "^5.0.0",
@@ -2195,9 +2195,9 @@
       }
     },
     "node_modules/@commitlint/types": {
-      "version": "18.4.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-18.4.4.tgz",
-      "integrity": "sha512-/FykLtodD8gKs3+VNkAUwofu4LBHankclj+I8fB2jTRvG6PV7k/OUt4P+VbM7ip853qS4F0g7Z6hLNa6JeMcAQ==",
+      "version": "18.6.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-18.6.0.tgz",
+      "integrity": "sha512-oavoKLML/eJa2rJeyYSbyGAYzTxQ6voG5oeX3OrxpfrkRWhJfm4ACnhoRf5tgiybx2MZ+EVFqC1Lw3W8/uwpZA==",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -3449,9 +3449,9 @@
       }
     },
     "node_modules/@electron/notarize": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.2.0.tgz",
-      "integrity": "sha512-Sf7RG47rafeGuUm+kLEbTXMN8XZeYXN70dMBstrcgiykxCq3SLl1uqxFWndxSI1LfMqv4Eq9PTDHLPwiya31Kg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.2.1.tgz",
+      "integrity": "sha512-aL+bFMIkpR0cmmj5Zgy0LMKEpgy43/hw5zadEArgmAMWWlKc5buwFvFT9G/o/YJkvXAJm5q3iuTuLaiaXW39sg==",
       "dev": true,
       "dependencies": {
         "debug": "^4.1.1",
@@ -3583,9 +3583,9 @@
       "dev": true
     },
     "node_modules/@electron/rebuild": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.5.0.tgz",
-      "integrity": "sha512-pWRza7F+JxzTNATkEgI5iW7lAQTVBtU5r6ZjUSbrD04kbuQWUIHBcuvqosaHvKLmTpdRlsZQkPxTYciIoOWf3A==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.6.0.tgz",
+      "integrity": "sha512-zF4x3QupRU3uNGaP5X1wjpmcjfw1H87kyqZ00Tc3HvriV+4gmOGuvQjGNkrJuXdsApssdNyVwLsy+TaeTGGcVw==",
       "dev": true,
       "dependencies": {
         "@malept/cross-spawn-promise": "^2.0.0",
@@ -3931,9 +3931,9 @@
       "integrity": "sha512-iRP+QKI2+oz3UAh4nPEq14CsEjrjD6a5+fuypjScisAh9kXKFvdJOZJDwk7kikLvWVLGEs9+kIUS4LPQV7VZVw=="
     },
     "node_modules/@firebase/app": {
-      "version": "0.9.25",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.9.25.tgz",
-      "integrity": "sha512-fX22gL5USXhOK21Hlh3oTeOzQZ6th6S2JrjXNEpBARmwzuUkqmVGVdsOCIFYIsLpK0dQE3o8xZnLrRg5wnzZ/g==",
+      "version": "0.9.26",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.9.26.tgz",
+      "integrity": "sha512-zCjo6KhNhbuFB+V+Z4H9g4+BZ78E7n3ShxaBtuIcRkpwdm7+1BsafzChOsDYuI86m97HUWsyLPurLBhqcupFFA==",
       "dependencies": {
         "@firebase/component": "0.6.4",
         "@firebase/logger": "0.4.0",
@@ -3983,11 +3983,11 @@
       "integrity": "sha512-uwSUj32Mlubybw7tedRzR24RP8M8JUVR3NPiMk3/Z4bCmgEKTlQBwMXrehDAZ2wF+TsBq0SN1c6ema71U/JPyQ=="
     },
     "node_modules/@firebase/app-compat": {
-      "version": "0.2.25",
-      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.25.tgz",
-      "integrity": "sha512-B/JtCp1FsTuzlh1tIGQpYM2AXps21/zlzpFsk5LRsROOTRhBcR2N45AyaONPFD06C0yS0Tw19foxADzHyOSC3A==",
+      "version": "0.2.26",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.26.tgz",
+      "integrity": "sha512-tVNOYvB3lIFkN3RmcTieo5qYRIkYak9iC6E7dZMxax52uMIUJiIKKtPkarbwZh6EnUxru5hJRo8tfUZGuaQDQw==",
       "dependencies": {
-        "@firebase/app": "0.9.25",
+        "@firebase/app": "0.9.26",
         "@firebase/component": "0.6.4",
         "@firebase/logger": "0.4.0",
         "@firebase/util": "1.9.3",
@@ -3998,6 +3998,43 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.0.tgz",
       "integrity": "sha512-AeweANOIo0Mb8GiYm3xhTEBVCmPwTYAu9Hcd2qSkLuga/6+j9b1Jskl5bpiSQWy9eJ/j5pavxj6eYogmnuzm+Q=="
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.5.1.tgz",
+      "integrity": "sha512-rgDZnrDoekRvtzXVji8Z61wxxkof6pTkjYEkybILrjM8tGP9tx4xa9qGpF4ax3AzF+rKr7mIa9NnoXEK4UNqmQ==",
+      "dependencies": {
+        "@firebase/auth": "1.5.1",
+        "@firebase/auth-types": "0.12.0",
+        "@firebase/component": "0.6.4",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0",
+        "undici": "5.26.5"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-compat/node_modules/@firebase/auth": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.5.1.tgz",
+      "integrity": "sha512-sVi7rq2YneLGJFqHa5S6nDfCHix9yuVV3RLhj/pWPlB4a36ofXal4E6PJwpeMc8uLjWEr1aovYN1jkXWNB6Avw==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0",
+        "undici": "5.26.5"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^1.18.1"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@firebase/auth-interop-types": {
       "version": "0.2.1",
@@ -4059,9 +4096,9 @@
       }
     },
     "node_modules/@firebase/firestore": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.4.0.tgz",
-      "integrity": "sha512-VeDXD9PUjvcWY1tInBOMTIu2pijR3YYy+QAe5cxCo1Q1vW+aA/mpQHhebPM1J6b4Zd1MuUh8xpBRvH9ujKR56A==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.4.1.tgz",
+      "integrity": "sha512-LCWZZ+rgNET1qw3vpugmGCJZVbz7c5NkgKect5pZn36gaBzGVb8+pRQ8WSZ1veYVMOK6SKrBkS1Rw6EqcmPnyw==",
       "dependencies": {
         "@firebase/component": "0.6.4",
         "@firebase/logger": "0.4.0",
@@ -4080,12 +4117,12 @@
       }
     },
     "node_modules/@firebase/firestore-compat": {
-      "version": "0.3.23",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.23.tgz",
-      "integrity": "sha512-uUTBiP0GLVBETaOCfB11d33OWB8x1r2G1Xrl0sRK3Va0N5LJ/GRvKVSGfM7VScj+ypeHe8RpdwKoCqLpN1e+uA==",
+      "version": "0.3.24",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.24.tgz",
+      "integrity": "sha512-Wj5cgqmQwTnqHS4KabOpXCNIaSTtVDP1NitnhjXff04Q4QK0aeIbeO1TPlSSTmUb6S7KzoKD4XR99hfKZDYbfA==",
       "dependencies": {
         "@firebase/component": "0.6.4",
-        "@firebase/firestore": "4.4.0",
+        "@firebase/firestore": "4.4.1",
         "@firebase/firestore-types": "3.0.0",
         "@firebase/util": "1.9.3",
         "tslib": "^2.1.0"
@@ -4511,9 +4548,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.9.13",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.13.tgz",
-      "integrity": "sha512-OEZZu9v9AA+7/tghMDE8o5DAMD5THVnwSqDWuh7PPYO5287rTyqy0xEHT6/e4pbqSrhyLPdQFsam4TwFQVVIIw==",
+      "version": "1.9.14",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.14.tgz",
+      "integrity": "sha512-nOpuzZ2G3IuMFN+UPPpKrC6NsLmWsTqSsm66IRfnBt1D4pwTqE27lmbpcPM+l2Ua4gE7PfjRHI6uedAy7hoXUw==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.8",
         "@types/node": ">=12.12.47"
@@ -4585,13 +4622,13 @@
       "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw=="
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-1.5.0.tgz",
-      "integrity": "sha512-3cKJkW1vIZAs4NaS0reFsnpAjP0azffYII4I2R7PTI7ZTMg5Y1at4vzXccOH3762b2c2L4drBhpJpf9uiaGNxA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-1.5.2.tgz",
+      "integrity": "sha512-CifrkgQjDkUkWexmgYYNyB5603HhTHI91vLFeQXh6qrTKiCMVASol01Rs1cv6LP/A2WccZSRlJKZhbaBIs/9ZA==",
       "dev": true,
       "dependencies": {
-        "@inquirer/core": "^5.1.1",
-        "@inquirer/type": "^1.1.5",
+        "@inquirer/core": "^6.0.0",
+        "@inquirer/type": "^1.1.6",
         "ansi-escapes": "^4.3.2",
         "chalk": "^4.1.2",
         "figures": "^3.2.0"
@@ -4671,13 +4708,13 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-2.0.15.tgz",
-      "integrity": "sha512-hj8Q/z7sQXsF0DSpLQZVDhWYGN6KLM/gNjjqGkpKwBzljbQofGjn0ueHADy4HUY+OqDHmXuwk/bY+tZyIuuB0w==",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-2.0.17.tgz",
+      "integrity": "sha512-EqzhGryzmGpy2aJf6LxJVhndxYmFs+m8cxXzf8nejb1DE3sabf6mUgBcp4J0jAUEiAcYzqmkqRr7LPFh/WdnXA==",
       "dev": true,
       "dependencies": {
-        "@inquirer/core": "^5.1.1",
-        "@inquirer/type": "^1.1.5",
+        "@inquirer/core": "^6.0.0",
+        "@inquirer/type": "^1.1.6",
         "chalk": "^4.1.2"
       },
       "engines": {
@@ -4755,18 +4792,18 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-5.1.1.tgz",
-      "integrity": "sha512-IuJyZQUg75+L5AmopgnzxYrgcU6PJKL0hoIs332G1Gv55CnmZrhG6BzNOeZ5sOsTi1YCGOopw4rYICv74ejMFg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-6.0.0.tgz",
+      "integrity": "sha512-fKi63Khkisgda3ohnskNf5uZJj+zXOaBvOllHsOkdsXRA/ubQLJQrZchFFi57NKbZzkTunXiBMdvWOv71alonw==",
       "dev": true,
       "dependencies": {
-        "@inquirer/type": "^1.1.5",
+        "@inquirer/type": "^1.1.6",
         "@types/mute-stream": "^0.0.4",
-        "@types/node": "^20.9.0",
+        "@types/node": "^20.10.7",
         "@types/wrap-ansi": "^3.0.0",
         "ansi-escapes": "^4.3.2",
         "chalk": "^4.1.2",
-        "cli-spinners": "^2.9.1",
+        "cli-spinners": "^2.9.2",
         "cli-width": "^4.1.0",
         "figures": "^3.2.0",
         "mute-stream": "^1.0.0",
@@ -4850,13 +4887,13 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-1.2.13.tgz",
-      "integrity": "sha512-gBxjqt0B9GLN0j6M/tkEcmcIvB2fo9Cw0f5NRqDTkYyB9AaCzj7qvgG0onQ3GVPbMyMbbP4tWYxrBOaOdKpzNA==",
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-1.2.15.tgz",
+      "integrity": "sha512-gQ77Ls09x5vKLVNMH9q/7xvYPT6sIs5f7URksw+a2iJZ0j48tVS6crLqm2ugG33tgXHIwiEqkytY60Zyh5GkJQ==",
       "dev": true,
       "dependencies": {
-        "@inquirer/core": "^5.1.1",
-        "@inquirer/type": "^1.1.5",
+        "@inquirer/core": "^6.0.0",
+        "@inquirer/type": "^1.1.6",
         "chalk": "^4.1.2",
         "external-editor": "^3.1.0"
       },
@@ -4935,13 +4972,13 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-1.1.14.tgz",
-      "integrity": "sha512-yS6fJ8jZYAsxdxuw2c8XTFMTvMR1NxZAw3LxDaFnqh7BZ++wTQ6rSp/2gGJhMacdZ85osb+tHxjVgx7F+ilv5g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-1.1.16.tgz",
+      "integrity": "sha512-TGLU9egcuo+s7PxphKUCnJnpCIVY32/EwPCLLuu+gTvYiD8hZgx8Z2niNQD36sa6xcfpdLY6xXDBiL/+g1r2XQ==",
       "dev": true,
       "dependencies": {
-        "@inquirer/core": "^5.1.1",
-        "@inquirer/type": "^1.1.5",
+        "@inquirer/core": "^6.0.0",
+        "@inquirer/type": "^1.1.6",
         "chalk": "^4.1.2",
         "figures": "^3.2.0"
       },
@@ -5020,13 +5057,13 @@
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-1.2.14.tgz",
-      "integrity": "sha512-tISLGpUKXixIQue7jypNEShrdzJoLvEvZOJ4QRsw5XTfrIYfoWFqAjMQLerGs9CzR86yAI89JR6snHmKwnNddw==",
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-1.2.16.tgz",
+      "integrity": "sha512-Ou0LaSWvj1ni+egnyQ+NBtfM1885UwhRCMtsRt2bBO47DoC1dwtCa+ZUNgrxlnCHHF0IXsbQHYtIIjFGAavI4g==",
       "dev": true,
       "dependencies": {
-        "@inquirer/core": "^5.1.1",
-        "@inquirer/type": "^1.1.5",
+        "@inquirer/core": "^6.0.0",
+        "@inquirer/type": "^1.1.6",
         "chalk": "^4.1.2"
       },
       "engines": {
@@ -5104,13 +5141,13 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-1.1.14.tgz",
-      "integrity": "sha512-vL2BFxfMo8EvuGuZYlryiyAB3XsgtbxOcFs4H9WI9szAS/VZCAwdVqs8rqEeaAf/GV/eZOghIOYxvD91IsRWSg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-1.1.16.tgz",
+      "integrity": "sha512-aZYZVHLUXZ2gbBot+i+zOJrks1WaiI95lvZCn1sKfcw6MtSSlYC8uDX8sTzQvAsQ8epHoP84UNvAIT0KVGOGqw==",
       "dev": true,
       "dependencies": {
-        "@inquirer/input": "^1.2.14",
-        "@inquirer/type": "^1.1.5",
+        "@inquirer/core": "^6.0.0",
+        "@inquirer/type": "^1.1.6",
         "ansi-escapes": "^4.3.2",
         "chalk": "^4.1.2"
       },
@@ -5189,33 +5226,33 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-3.3.0.tgz",
-      "integrity": "sha512-BBCqdSnhNs+WziSIo4f/RNDu6HAj4R/Q5nMgJb5MNPFX8sJGCvj9BoALdmR0HTWXyDS7TO8euKj6W6vtqCQG7A==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-3.3.2.tgz",
+      "integrity": "sha512-k52mOMRvTUejrqyF1h8Z07chC+sbaoaUYzzr1KrJXyj7yaX7Nrh0a9vktv8TuocRwIJOQMaj5oZEmkspEcJFYQ==",
       "dev": true,
       "dependencies": {
-        "@inquirer/checkbox": "^1.5.0",
-        "@inquirer/confirm": "^2.0.15",
-        "@inquirer/core": "^5.1.1",
-        "@inquirer/editor": "^1.2.13",
-        "@inquirer/expand": "^1.1.14",
-        "@inquirer/input": "^1.2.14",
-        "@inquirer/password": "^1.1.14",
-        "@inquirer/rawlist": "^1.2.14",
-        "@inquirer/select": "^1.3.1"
+        "@inquirer/checkbox": "^1.5.2",
+        "@inquirer/confirm": "^2.0.17",
+        "@inquirer/core": "^6.0.0",
+        "@inquirer/editor": "^1.2.15",
+        "@inquirer/expand": "^1.1.16",
+        "@inquirer/input": "^1.2.16",
+        "@inquirer/password": "^1.1.16",
+        "@inquirer/rawlist": "^1.2.16",
+        "@inquirer/select": "^1.3.3"
       },
       "engines": {
         "node": ">=14.18.0"
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-1.2.14.tgz",
-      "integrity": "sha512-xIYmDpYgfz2XGCKubSDLKEvadkIZAKbehHdWF082AyC2I4eHK44RUfXaoOAqnbqItZq4KHXS6jDJ78F2BmQvxg==",
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-1.2.16.tgz",
+      "integrity": "sha512-pZ6TRg2qMwZAOZAV6TvghCtkr53dGnK29GMNQ3vMZXSNguvGqtOVc4j/h1T8kqGJFagjyfBZhUPGwNS55O5qPQ==",
       "dev": true,
       "dependencies": {
-        "@inquirer/core": "^5.1.1",
-        "@inquirer/type": "^1.1.5",
+        "@inquirer/core": "^6.0.0",
+        "@inquirer/type": "^1.1.6",
         "chalk": "^4.1.2"
       },
       "engines": {
@@ -5293,13 +5330,13 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-1.3.1.tgz",
-      "integrity": "sha512-EgOPHv7XOHEqiBwBJTyiMg9r57ySyW4oyYCumGp+pGyOaXQaLb2kTnccWI6NFd9HSi5kDJhF7YjA+3RfMQJ2JQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-1.3.3.tgz",
+      "integrity": "sha512-RzlRISXWqIKEf83FDC9ZtJ3JvuK1l7aGpretf41BCWYrvla2wU8W8MTRNMiPrPJ+1SIqrRC1nZdZ60hD9hRXLg==",
       "dev": true,
       "dependencies": {
-        "@inquirer/core": "^5.1.1",
-        "@inquirer/type": "^1.1.5",
+        "@inquirer/core": "^6.0.0",
+        "@inquirer/type": "^1.1.6",
         "ansi-escapes": "^4.3.2",
         "chalk": "^4.1.2",
         "figures": "^3.2.0"
@@ -5379,9 +5416,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.1.5.tgz",
-      "integrity": "sha512-wmwHvHozpPo4IZkkNtbYenem/0wnfI6hvOcGKmPEa0DwuaH5XUQzFqy6OpEpjEegZMhYIk8HDYITI16BPLtrRA==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.1.6.tgz",
+      "integrity": "sha512-OCKOpn0CrFDslR8s3who7hlr823zXTb1iShGCaaWgEJFfkIV0T9aLZV2QGnOuU78IrsPYLkr3oKx9dZwwCH3Rw==",
       "dev": true,
       "engines": {
         "node": ">=14.18.0"
@@ -6184,9 +6221,9 @@
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.21",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.21.tgz",
-      "integrity": "sha512-SRfKmRe1KvYnxjEMtxEr+J4HIeMX5YBg/qhRHpxEIGjhX1rshcHlnFUE9K0GazhVKWM7B+nARSkV8LuvJdJ5/g==",
+      "version": "0.3.22",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz",
+      "integrity": "sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -6432,9 +6469,9 @@
       }
     },
     "node_modules/@npmcli/agent/node_modules/lru-cache": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
-      "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
       "dev": true,
       "optional": true,
       "engines": {
@@ -6798,9 +6835,9 @@
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
     },
     "node_modules/@rushstack/eslint-patch": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.6.1.tgz",
-      "integrity": "sha512-UY+FGM/2jjMkzQLn8pxcHGMaVLh9aEitG3zY2CiY7XHdLiz3bZOwa6oDxNqEMv7zZkV+cj5DOdz0cQ1BP5Hjgw=="
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.7.2.tgz",
+      "integrity": "sha512-RbhOOTCNoCrbfkRyoXODZp75MlpiHMgbE5MEBZAnnnLyQNgrigEj4p0lzsMDyc1zVsJDLrivB58tgg3emX0eEA=="
     },
     "node_modules/@serialport/binding-abstract": {
       "version": "8.0.6",
@@ -6905,9 +6942,9 @@
       }
     },
     "node_modules/@sideway/address": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
-      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
       "dev": true,
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
@@ -7384,9 +7421,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.41",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.41.tgz",
-      "integrity": "sha512-OaJ7XLaelTgrvlZD8/aa0vvvxZdUmlCn6MtWeB7TkiKW70BQLc9XEPpDLPdbo52ZhXUCrznlWdCHWxJWtdyajA==",
+      "version": "4.17.42",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.42.tgz",
+      "integrity": "sha512-ckM3jm2bf/MfB3+spLPWYPUH573plBFwpOhqQ2WottxYV85j1HQFlxmnTq57X1yHY9awZPig06hL/cLMgNWHIQ==",
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -7549,9 +7586,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.11.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.0.tgz",
-      "integrity": "sha512-o9bjXmDNcF7GbM4CNQpmi+TutCgap/K3w1JyKgxAjqx41zp9qlIAVFi0IhCNsJcXolEqLWhbFbEeL0PvYm4pcQ==",
+      "version": "20.11.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.11.tgz",
+      "integrity": "sha512-PlJCXfb57Jrman0H1BxO2+Q7qwih2Mwk7T6Gvixj+SK4mqs4RWOGMMoP6p/LFa3UrP2CZOO6ai6otd7J/TB6Ug==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -7595,9 +7632,9 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
     },
     "node_modules/@types/react": {
-      "version": "18.2.47",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.47.tgz",
-      "integrity": "sha512-xquNkkOirwyCgoClNk85BjP+aqnIS+ckAJ8i37gAbDs14jfW/J23f2GItAf33oiUPQnqNMALiFeoM9Y5mbjpVQ==",
+      "version": "18.2.48",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.48.tgz",
+      "integrity": "sha512-qboRCl6Ie70DQQG9hhNREz81jqC1cs9EVNcjQ1AU+jH6NFfSAhVVbrrY/+nSF+Bsk4AOwm9Qa61InvMCyV+H3w==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -9073,9 +9110,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.16",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.16.tgz",
-      "integrity": "sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==",
+      "version": "10.4.17",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.17.tgz",
+      "integrity": "sha512-/cpVNRLSfhOtcGflT13P2794gVSgmPgTR+erw5ifnMLZb0UnSlkK4tquLmkd3BhA+nLo5tX8Cu0upUsGKvKbmg==",
       "funding": [
         {
           "type": "opencollective",
@@ -9091,9 +9128,9 @@
         }
       ],
       "dependencies": {
-        "browserslist": "^4.21.10",
-        "caniuse-lite": "^1.0.30001538",
-        "fraction.js": "^4.3.6",
+        "browserslist": "^4.22.2",
+        "caniuse-lite": "^1.0.30001578",
+        "fraction.js": "^4.3.7",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
         "postcss-value-parser": "^4.2.0"
@@ -9143,9 +9180,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.5.tgz",
-      "integrity": "sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
       "dev": true,
       "dependencies": {
         "follow-redirects": "^1.15.4",
@@ -9384,12 +9421,12 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.7.tgz",
-      "integrity": "sha512-LidDk/tEGDfuHW2DWh/Hgo4rmnw3cduK6ZkOI1NPFceSK3n/yAGeOsNT7FLnSGHkXj3RHGSEVkN3FsCTY6w2CQ==",
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.8.tgz",
+      "integrity": "sha512-OtIuQfafSzpo/LhnJaykc0R/MMnuLSSVjVYy9mHArIZ9qTCSZ6TpWCuEKZYVoN//t8HqBNScHrOtCrIK5IaGLg==",
       "dependencies": {
         "@babel/compat-data": "^7.22.6",
-        "@babel/helper-define-polyfill-provider": "^0.4.4",
+        "@babel/helper-define-polyfill-provider": "^0.5.0",
         "semver": "^6.3.1"
       },
       "peerDependencies": {
@@ -9397,23 +9434,23 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs3": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.8.7.tgz",
-      "integrity": "sha512-KyDvZYxAzkC0Aj2dAPyDzi2Ym15e5JKZSK+maI7NAwSqofvuFglbSsxE7wUOvTg9oFVnHMzVzBKcqEb4PJgtOA==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.9.0.tgz",
+      "integrity": "sha512-7nZPG1uzK2Ymhy/NbaOWTg3uibM2BmGASS4vHS4szRZAIR8R6GwA/xAujpdrXU5iyklrimWnLWU+BLF9suPTqg==",
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.4.4",
-        "core-js-compat": "^3.33.1"
+        "@babel/helper-define-polyfill-provider": "^0.5.0",
+        "core-js-compat": "^3.34.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.4.tgz",
-      "integrity": "sha512-S/x2iOCvDaCASLYsOOgWOq4bCfKYVqvO/uxjkaYyZ3rVsVE3CeAI/c84NpyuBBymEgNvHgjEot3a9/Z/kXvqsg==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.5.tgz",
+      "integrity": "sha512-OJGYZlhLqBh2DDHeqAxWB1XIvr49CxiJ2gIt61/PU55CQK4Z58OzMqjDe1zwQdQk+rBYsRc+1rJmdajM3gimHg==",
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.4.4"
+        "@babel/helper-define-polyfill-provider": "^0.5.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -9863,9 +9900,9 @@
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
     },
     "node_modules/browserslist": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
-      "integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.3.tgz",
+      "integrity": "sha512-UAp55yfwNv0klWNapjs/ktHoguxuQNGnOzxYmfnXIS+8AsRDZkSDxg7R1AX3GKzn078SBI5dzwzj/Yx0Or0e3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -9881,8 +9918,8 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001565",
-        "electron-to-chromium": "^1.4.601",
+        "caniuse-lite": "^1.0.30001580",
+        "electron-to-chromium": "^1.4.648",
         "node-releases": "^2.0.14",
         "update-browserslist-db": "^1.0.13"
       },
@@ -10159,9 +10196,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001576",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz",
-      "integrity": "sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==",
+      "version": "1.0.30001581",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001581.tgz",
+      "integrity": "sha512-whlTkwhqV2tUmP3oYhtNfaWGYHDdS3JYFQBKXxcUR9qqPWsRhFHhoISO2Xnl/g0xyKzht9mI1LZpiNWfMzHixQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -11113,9 +11150,9 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
     "node_modules/core-js": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.35.0.tgz",
-      "integrity": "sha512-ntakECeqg81KqMueeGJ79Q5ZgQNR+6eaE8sxGCx62zMbAIj65q+uYvatToew3m6eAGdU4gNZwpZ34NMe4GYswg==",
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.35.1.tgz",
+      "integrity": "sha512-IgdsbxNyMskrTFxa9lWHyMwAJU5gXOPP+1yO+K59d50VLVAIDAbs7gIv705KzALModfK3ZrSZTPNpC0PQgIZuw==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -11123,9 +11160,9 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.35.0.tgz",
-      "integrity": "sha512-5blwFAddknKeNgsjBzilkdQ0+YK8L1PfqPYq40NOYMYFSS38qj+hpTcLLWwpIwA2A5bje/x5jmVn2tzUMg9IVw==",
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.35.1.tgz",
+      "integrity": "sha512-sftHa5qUJY3rs9Zht1WEnmkvXputCyDBczPnr7QDgL8n3qrF3CMXY4VPSYtOLLiOUJcah2WNXREd48iOl6mQIw==",
       "dependencies": {
         "browserslist": "^4.22.2"
       },
@@ -11135,9 +11172,9 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.35.0.tgz",
-      "integrity": "sha512-f+eRYmkou59uh7BPcyJ8MC76DiGhspj1KMxVIcF24tzP8NA9HVa1uC7BTW2tgx7E1QVCzDzsgp7kArrzhlz8Ew==",
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.35.1.tgz",
+      "integrity": "sha512-zcIdi/CL3MWbBJYo5YCeVAAx+Sy9yJE9I3/u9LkFABwbeaPhTMRWraM8mYFp9jW5Z50hOy7FVzCc8dCrpZqtIQ==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -11386,15 +11423,15 @@
       }
     },
     "node_modules/css-loader": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.9.0.tgz",
-      "integrity": "sha512-3I5Nu4ytWlHvOP6zItjiHlefBNtrH+oehq8tnQa2kO305qpVyx9XNIT1CXIj5bgCJs7qICBCkgCYxQLKPANoLA==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.10.0.tgz",
+      "integrity": "sha512-LTSA/jWbwdMlk+rhmElbDR2vbtQoTBPr7fkJE+mxrHj+7ru0hUmHafDRzWIjIHTwpitWVaqY2/UWGRca3yUgRw==",
       "dependencies": {
         "icss-utils": "^5.1.0",
-        "postcss": "^8.4.31",
+        "postcss": "^8.4.33",
         "postcss-modules-extract-imports": "^3.0.0",
-        "postcss-modules-local-by-default": "^4.0.3",
-        "postcss-modules-scope": "^3.1.0",
+        "postcss-modules-local-by-default": "^4.0.4",
+        "postcss-modules-scope": "^3.1.1",
         "postcss-modules-values": "^4.0.0",
         "postcss-value-parser": "^4.2.0",
         "semver": "^7.5.4"
@@ -11407,7 +11444,16 @@
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
+        "@rspack/core": "0.x || 1.x",
         "webpack": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rspack/core": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
       }
     },
     "node_modules/css-loader/node_modules/lru-cache": {
@@ -12406,9 +12452,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.1.tgz",
+      "integrity": "sha512-CjA3y+Dr3FyFDOAMnxZEGtnW9KBR2M0JvvUtXNW+dYJL5ROWxP9DUHCwgFqpMk0OXCc0ljhaNTr2w/kutYIcHQ==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -12514,9 +12560,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "27.2.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-27.2.2.tgz",
-      "integrity": "sha512-MdKwS3PGUzBpuBR1yDVb4hVzHx7Rv2PXiIP+2lK/o9F3xQtPYCZwy078Sw7utAt5ipvQKFrWhvH08WDOzyMjQw==",
+      "version": "27.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-27.3.0.tgz",
+      "integrity": "sha512-o+pYSNG8kfXPkQWu1lhLwHboQ9n+3cuhi6GBhiryUeqY76C1oEnrxYRzCuaD9T0V7qbbvO0ID0MXfFNVQJXVBQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -12815,9 +12861,9 @@
       }
     },
     "node_modules/electron-log": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.0.3.tgz",
-      "integrity": "sha512-jUgAuRjfpCD9tmH1F6fb195YsFfM/DkqkZLhFeo0VAAstantn11bxmgx63uE6KG/JljHG7sIkgM2QEjDimJI0g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.1.0.tgz",
+      "integrity": "sha512-Qwl8J41jqps2ibE2WSolOyoGkZ/kbpenggxPTCyT/0jlMl1DfPXpjROIL7m85SOhRkuw56sFGRG0rAlmzgxZQA==",
       "engines": {
         "node": ">= 14"
       }
@@ -12844,9 +12890,9 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.630",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.630.tgz",
-      "integrity": "sha512-osHqhtjojpCsACVnuD11xO5g9xaCyw7Qqn/C2KParkMv42i8jrJJgx3g7mkHfpxwhy9MnOJr8+pKOdZ7qzgizg=="
+      "version": "1.4.651",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.651.tgz",
+      "integrity": "sha512-jjks7Xx+4I7dslwsbaFocSwqBbGHQmuXBJUK9QBZTIrzPq3pzn6Uf2szFSP728FtLYE3ldiccmlkOM/zhGKCpA=="
     },
     "node_modules/electron-winstaller": {
       "version": "5.2.1",
@@ -12923,9 +12969,9 @@
       }
     },
     "node_modules/electron/node_modules/@types/node": {
-      "version": "18.19.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.6.tgz",
-      "integrity": "sha512-X36s5CXMrrJOs2lQCdDF68apW4Rfx9ixYMawlepwmE4Anezv/AV2LSpKD1Ub8DAc+urp5bk0BGZ6NtmBitfnsg==",
+      "version": "18.19.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.10.tgz",
+      "integrity": "sha512-IZD8kAM02AW1HRDTPOlz3npFava678pr8Ie9Vp8uRhBROXAv8MXT2pCnGZZAKYdromsNQLHQcfWQ6EOatVLtqA==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -14359,9 +14405,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.3.tgz",
-      "integrity": "sha512-coV/D1MhrShMvU6D0I+VAK3umz6hUaxxhL0yp/9RjfiYUfAv14rDhGQL+PLForhMdr0wq3PiV07WtkkNjJjNHg==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.4.tgz",
+      "integrity": "sha512-utnwm92SyozgA3hhH2I8qldf2lBqm6qHOICawRNRFu1qMe3+oqr+GcXjGqTmXTMGE5T4eC03kr/rlh5C1IRdZA==",
       "dev": true,
       "funding": [
         {
@@ -14382,9 +14428,9 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
-      "integrity": "sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.0.tgz",
+      "integrity": "sha512-zGygtijUMT7jnk3h26kUms3BkSDp4IfIKjmnqI2tvx6nuBfiF1UqOxbnLfzdv+apBy+53oaImsKtMw/xYbW+1w==",
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -14639,23 +14685,23 @@
       }
     },
     "node_modules/firebase": {
-      "version": "10.7.1",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-10.7.1.tgz",
-      "integrity": "sha512-Mlt7y7zQ43FtKp4SCyYie3tnrOL3UMF2XXiV4ZXMrC0d0wtcOYmABuybhkJpJCKILpdekxr39wjnaai0DZlWFg==",
+      "version": "10.7.2",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-10.7.2.tgz",
+      "integrity": "sha512-zED3kAJyf+Xx5tXpC3vjmlWTm/SIVoJJ6MOLuXYJkqKAUJLG7Q1Jxy6l1DxCzGgBqZHxc0Jh6q+qG++9kimHsw==",
       "dependencies": {
         "@firebase/analytics": "0.10.0",
         "@firebase/analytics-compat": "0.2.6",
-        "@firebase/app": "0.9.25",
+        "@firebase/app": "0.9.26",
         "@firebase/app-check": "0.8.1",
         "@firebase/app-check-compat": "0.3.8",
-        "@firebase/app-compat": "0.2.25",
+        "@firebase/app-compat": "0.2.26",
         "@firebase/app-types": "0.9.0",
         "@firebase/auth": "1.5.1",
         "@firebase/auth-compat": "0.5.1",
         "@firebase/database": "1.0.2",
         "@firebase/database-compat": "1.0.2",
-        "@firebase/firestore": "4.4.0",
-        "@firebase/firestore-compat": "0.3.23",
+        "@firebase/firestore": "4.4.1",
+        "@firebase/firestore-compat": "0.3.24",
         "@firebase/functions": "0.11.0",
         "@firebase/functions-compat": "0.3.6",
         "@firebase/installations": "0.6.4",
@@ -15128,22 +15174,6 @@
         "@react-native-async-storage/async-storage": {
           "optional": true
         }
-      }
-    },
-    "node_modules/firebase/node_modules/@firebase/auth-compat": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.5.1.tgz",
-      "integrity": "sha512-rgDZnrDoekRvtzXVji8Z61wxxkof6pTkjYEkybILrjM8tGP9tx4xa9qGpF4ax3AzF+rKr7mIa9NnoXEK4UNqmQ==",
-      "dependencies": {
-        "@firebase/auth": "1.5.1",
-        "@firebase/auth-types": "0.12.0",
-        "@firebase/component": "0.6.4",
-        "@firebase/util": "1.9.3",
-        "tslib": "^2.1.0",
-        "undici": "5.26.5"
-      },
-      "peerDependencies": {
-        "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/flat-cache": {
@@ -16812,17 +16842,6 @@
         }
       }
     },
-    "node_modules/http-proxy-middleware/node_modules/is-plain-obj": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
-      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -17631,6 +17650,17 @@
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -20300,14 +20330,14 @@
       "dev": true
     },
     "node_modules/joi": {
-      "version": "17.11.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.11.0.tgz",
-      "integrity": "sha512-NgB+lZLNoqISVy1rZocE9PZI36bL/77ie924Ri43yEvi9GUUMPeyVIr8KdFTMUlby1p0PBYMk9spIxEUQYqrJQ==",
+      "version": "17.12.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.12.1.tgz",
+      "integrity": "sha512-vtxmq+Lsc5SlfqotnfVjlViWfOL9nt/avKNbKYizwf6gsCfq9NYY/ceYRMFD8XDdrjJ9abJyScWmhmIiy+XRtQ==",
       "dev": true,
       "dependencies": {
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/topo": "^5.0.0",
-        "@sideway/address": "^4.1.3",
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
         "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
       }
@@ -20322,12 +20352,6 @@
         "url-join": "0.0.1",
         "valid-url": "^1"
       }
-    },
-    "node_modules/join-path/node_modules/url-join": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
-      "integrity": "sha512-H6dnQ/yPAAVzMQRvEvyz01hhfQL5qRWSEt7BX8t9DqnPw9BjMb64fjIRq76Uvf1hkHp+mTZvEVJ5guXOT0Xqaw==",
-      "dev": true
     },
     "node_modules/jose": {
       "version": "4.15.4",
@@ -21288,9 +21312,9 @@
       }
     },
     "node_modules/lint-staged/node_modules/string-width": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.0.0.tgz",
-      "integrity": "sha512-GPQHj7row82Hjo9hKZieKcHIhaAIKOJvFSIZXuCU9OASVZrMNUaZuz++SPVrBjnLsnk4k+z9f2EIypgxf2vNFw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.1.0.tgz",
+      "integrity": "sha512-SEIJCWiX7Kg4c129n48aDRwLbFb2LJmXXFrWBG4NGaRtMQ3myKPKbwrD1BKqQn74oCoNMBVrfDEr5M9YxCsrkw==",
       "dev": true,
       "dependencies": {
         "emoji-regex": "^10.3.0",
@@ -22197,15 +22221,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/mem/node_modules/p-is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -23360,6 +23375,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/p-is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -23650,9 +23674,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
-      "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
       "engines": {
         "node": "14 || >=16.14"
       }
@@ -24616,9 +24640,9 @@
       }
     },
     "node_modules/postcss-modules-local-by-default": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.3.tgz",
-      "integrity": "sha512-2/u2zraspoACtrbFRnTijMiQtb4GW4BvatjaG/bCjYQo8kLTdevCUlwuBHx2sCnSyrI3x3qj4ZK1j5LQBgzmwA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.4.tgz",
+      "integrity": "sha512-L4QzMnOdVwRm1Qb8m4x8jsZzKAaPAgrUF1r/hjDR2Xj7R+8Zsf97jAlSQzWtKx5YNiNGN8QxmPFIc/sh+RQl+Q==",
       "dependencies": {
         "icss-utils": "^5.0.0",
         "postcss-selector-parser": "^6.0.2",
@@ -24632,9 +24656,9 @@
       }
     },
     "node_modules/postcss-modules-scope": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.1.0.tgz",
-      "integrity": "sha512-SaIbK8XW+MZbd0xHPf7kdfA/3eOt7vxJ72IRecn3EzuZVLr1r0orzf0MX/pN8m+NMDoo6X/SQd8oeKqGZd8PXg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.1.1.tgz",
+      "integrity": "sha512-uZgqzdTleelWjzJY+Fhti6F3C9iF1JR/dODLs/JDefozYcKTBCdD8BIl6nNPbTbcLnGrk56hzwZC2DaGNvYjzA==",
       "dependencies": {
         "postcss-selector-parser": "^6.0.4"
       },
@@ -25499,9 +25523,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
-      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -26108,9 +26132,9 @@
       }
     },
     "node_modules/re2/node_modules/lru-cache": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
-      "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
       "dev": true,
       "optional": true,
       "engines": {
@@ -27028,6 +27052,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/registry-auth-token": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.0.2.tgz",
+      "integrity": "sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==",
+      "dev": true,
+      "dependencies": {
+        "@pnpm/npm-conf": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/registry-url": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
@@ -27475,9 +27511,9 @@
       }
     },
     "node_modules/rfdc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
-      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.1.tgz",
+      "integrity": "sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg==",
       "dev": true
     },
     "node_modules/rimraf": {
@@ -27661,12 +27697,12 @@
       }
     },
     "node_modules/safe-array-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
-      "integrity": "sha512-6XbUAseYE2KtOuGueyeobCySj9L4+66Tn6KQMOPQJrAJEowYKW/YR/MGJZl7FdydUdaFu4LYyDZjxf4/Nmo23Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.0.tgz",
+      "integrity": "sha512-ZdQ0Jeb9Ofti4hbt5lX3T2JcAamT9hfzYU1MNB+z/jaEbB6wfFfPIR/zEORmZqobkCCJhSjodobH6WHNmJ97dg==",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.1",
+        "call-bind": "^1.0.5",
+        "get-intrinsic": "^1.2.2",
         "has-symbols": "^1.0.3",
         "isarray": "^2.0.5"
       },
@@ -28087,14 +28123,15 @@
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
     "node_modules/set-function-length": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
-      "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.0.tgz",
+      "integrity": "sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==",
       "dependencies": {
         "define-data-property": "^1.1.1",
-        "get-intrinsic": "^1.2.1",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.2",
         "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0"
+        "has-property-descriptors": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -28441,9 +28478,9 @@
       }
     },
     "node_modules/spdx-exceptions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.4.0.tgz",
+      "integrity": "sha512-hcjppoJ68fhxA/cjbN4T8N6uCUejN8yFw69ttpqtBeCbF3u13n7mb31NB9jKwGTTWWnt9IbRA/mf1FprYS8wfw==",
       "dev": true
     },
     "node_modules/spdx-expression-parse": {
@@ -28625,9 +28662,9 @@
       }
     },
     "node_modules/stream-shift": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.2.tgz",
-      "integrity": "sha512-rV4Bovi9xx0BFzOb/X0B2GqoIjvqPCttZdu0Wgtx2Dxkj7ETyWl9gmqJ4EutWRLvtZWm8dxE+InQZX1IryZn/w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
       "dev": true
     },
     "node_modules/string_decoder": {
@@ -29476,6 +29513,45 @@
         "rimraf": "bin.js"
       }
     },
+    "node_modules/tempy": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-0.6.0.tgz",
+      "integrity": "sha512-G13vtMYPT/J8A4X2SjdtBTphZlrp1gKv6hZiOjw14RCWg6GbHuQBGtjlx75xLbYV/wEc0D7G5K4rxKP/cXk8Bw==",
+      "dependencies": {
+        "is-stream": "^2.0.0",
+        "temp-dir": "^2.0.0",
+        "type-fest": "^0.16.0",
+        "unique-string": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tempy/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tempy/node_modules/type-fest": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
+      "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/terminal-link": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -29492,9 +29568,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.26.0.tgz",
-      "integrity": "sha512-dytTGoE2oHgbNV9nTzgBEPaqAWvcJNl66VZ0BkJqlvp71IjO8CxdBx/ykCNb47cLnCmCvRZ6ZR0tLkqvZCdVBQ==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.27.0.tgz",
+      "integrity": "sha512-bi1HRwVRskAjheeYl291n3JC4GgO/Ty4z1nVs5AAsmonJulGxpSektecnNedrwK9C7vpvVtcX3cw00VSLt7U2A==",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -30320,18 +30396,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/update-notifier-cjs/node_modules/registry-auth-token": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.0.2.tgz",
-      "integrity": "sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==",
-      "dev": true,
-      "dependencies": {
-        "@pnpm/npm-conf": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/update-notifier-cjs/node_modules/semver": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
@@ -30380,6 +30444,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/url-join": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
+      "integrity": "sha512-H6dnQ/yPAAVzMQRvEvyz01hhfQL5qRWSEt7BX8t9DqnPw9BjMb64fjIRq76Uvf1hkHp+mTZvEVJ5guXOT0Xqaw==",
+      "dev": true
     },
     "node_modules/url-parse": {
       "version": "1.5.10",
@@ -30729,18 +30799,18 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
+      "version": "5.90.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.90.0.tgz",
+      "integrity": "sha512-bdmyXRCXeeNIePv6R6tGPyy20aUobw4Zy8r0LUS2EWO+U+Ke/gYDgsCh7bl5rB6jPpr4r0SZa6dPxBxLooDT3w==",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
+        "@types/estree": "^1.0.5",
         "@webassemblyjs/ast": "^1.11.5",
         "@webassemblyjs/wasm-edit": "^1.11.5",
         "@webassemblyjs/wasm-parser": "^1.11.5",
         "acorn": "^8.7.1",
         "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
+        "browserslist": "^4.21.10",
         "chrome-trace-event": "^1.0.2",
         "enhanced-resolve": "^5.15.0",
         "es-module-lexer": "^1.2.1",
@@ -30754,7 +30824,7 @@
         "neo-async": "^2.6.2",
         "schema-utils": "^3.2.0",
         "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
+        "terser-webpack-plugin": "^5.3.10",
         "watchpack": "^2.4.0",
         "webpack-sources": "^3.2.3"
       },
@@ -31307,17 +31377,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/workbox-build/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/workbox-build/node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -31337,40 +31396,12 @@
         "node": ">= 8"
       }
     },
-    "node_modules/workbox-build/node_modules/tempy": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tempy/-/tempy-0.6.0.tgz",
-      "integrity": "sha512-G13vtMYPT/J8A4X2SjdtBTphZlrp1gKv6hZiOjw14RCWg6GbHuQBGtjlx75xLbYV/wEc0D7G5K4rxKP/cXk8Bw==",
-      "dependencies": {
-        "is-stream": "^2.0.0",
-        "temp-dir": "^2.0.0",
-        "type-fest": "^0.16.0",
-        "unique-string": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/workbox-build/node_modules/tr46": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
       "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/workbox-build/node_modules/type-fest": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
-      "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/workbox-build/node_modules/webidl-conversions": {

--- a/src/experiment/blocks/honeycombBlock.js
+++ b/src/experiment/blocks/honeycombBlock.js
@@ -32,7 +32,7 @@ export function buildHoneycombBlock(jsPsych) {
     type: imageKeyboardResponse,
     // Display the image passed as a timeline variable
     stimulus: jsPsych.timelineVariable("stimulus"),
-    prompt: () => {
+    prompt: function () {
       // Conditionally displays the photodiodeGhostBox
       if (config.USE_PHOTODIODE) return photodiodeGhostBox;
       else return null;
@@ -44,12 +44,12 @@ export function buildHoneycombBlock(jsPsych) {
       code: eventCodes.honeycomb,
       correct_response: jsPsych.timelineVariable("correct_response"),
     },
-    on_load: () => {
+    on_load: function () {
       // Conditionally flashes the photodiode when the trial first loads
       if (config.USE_PHOTODIODE) pdSpotEncode(eventCodes.honeycomb);
     },
     // Add a boolean value ("correct") to the data - if the user responded with the correct key or not
-    on_finish: (data) => {
+    on_finish: function (data) {
       data.correct = jsPsych.pluginAPI.compareKeys(data.response, data.correct_response);
     },
   };

--- a/src/experiment/honeycomb.js
+++ b/src/experiment/honeycomb.js
@@ -14,7 +14,9 @@ import { buildDebriefTrial, instructionsTrial, preloadTrial } from "./trials/hon
  * Note that Honeycomb combines these with other options required for Honeycomb to operate correctly
  */
 export const honeycombOptions = {
-  on_finish: (data) => console.log("The experiment has finished:", data),
+  on_finish: function (data) {
+    return console.log("The experiment has finished:", data);
+  },
 };
 
 /**

--- a/src/experiment/honeycomb.js
+++ b/src/experiment/honeycomb.js
@@ -15,7 +15,7 @@ import { buildDebriefTrial, instructionsTrial, preloadTrial } from "./trials/hon
  */
 export const honeycombOptions = {
   on_finish: function (data) {
-    return console.log("The experiment has finished:", data);
+    console.log("The experiment has finished:", data);
   },
 };
 

--- a/src/experiment/index.js
+++ b/src/experiment/index.js
@@ -17,7 +17,9 @@ import "../lib/markup/trials.css";
  */
 export const jsPsychOptions = {
   ...honeycombOptions,
-  on_trial_finish: (data) => console.log(`Trial ${data.internal_node_id} just finished:`, data),
+  on_trial_finish: function (data) {
+    console.log(`Trial ${data.internal_node_id} just finished:`, data);
+  },
 };
 
 /**

--- a/src/experiment/trials/adjustVolume.js
+++ b/src/experiment/trials/adjustVolume.js
@@ -5,7 +5,7 @@ import { div, h1 } from "../../lib/markup/tags";
 /** Trial that prompts the user to adjust the volume on their computer */
 export const adjustVolumeTrial = {
   type: htmlKeyboardResponse,
-  stimulus: () => {
+  stimulus: function () {
     const adjustVolumeMarkup = h1(LANGUAGE.trials.adjustVolume);
     return div(adjustVolumeMarkup, { class: "bottom-prompt" });
   },

--- a/src/experiment/trials/camera.js
+++ b/src/experiment/trials/camera.js
@@ -55,18 +55,18 @@ export function buildCameraStartTrial(jsPsych) {
           const cameraChunks = [];
 
           // Push data whenever available
-          cameraRecorder.addEventListener("dataavailable", function (event) {
+          cameraRecorder.addEventListener("dataavailable", (event) => {
             if (event.data.size > 0) cameraChunks.push(event.data);
           });
 
           // Saves the raw data feed from the participants camera (executed on cameraRecorder.stop()).
-          cameraRecorder.addEventListener("stop", function () {
+          cameraRecorder.addEventListener("stop", () => {
             const blob = new Blob(cameraChunks, { type: cameraRecorder.mimeType });
 
             // Pass video data to Electron as a base64 encoded string
             const reader = new FileReader();
             reader.readAsDataURL(blob);
-            reader.onloadend = function () {
+            reader.onloadend = () => {
               window.electronAPI.saveVideo(reader.result);
             };
           });

--- a/src/experiment/trials/camera.js
+++ b/src/experiment/trials/camera.js
@@ -24,7 +24,7 @@ export function buildCameraStartTrial(jsPsych) {
       {
         // Helps participant center themselves inside the camera
         type: htmlButtonResponse,
-        stimulus: () => {
+        stimulus: function () {
           const videoMarkup = tag("video", "", {
             id: "webcam",
             width: 640,
@@ -40,7 +40,7 @@ export function buildCameraStartTrial(jsPsych) {
         },
         choices: [LANGUAGE.prompts.continue.button],
         response_ends_trial: true,
-        on_start: () => {
+        on_start: function () {
           // Initialize and store the camera feed
           if (!config.USE_ELECTRON) {
             // TODO #343: We should be able to make this work on both electron and browser?
@@ -55,27 +55,29 @@ export function buildCameraStartTrial(jsPsych) {
           const cameraChunks = [];
 
           // Push data whenever available
-          cameraRecorder.addEventListener("dataavailable", (event) => {
+          cameraRecorder.addEventListener("dataavailable", function (event) {
             if (event.data.size > 0) cameraChunks.push(event.data);
           });
 
           // Saves the raw data feed from the participants camera (executed on cameraRecorder.stop()).
-          cameraRecorder.addEventListener("stop", () => {
+          cameraRecorder.addEventListener("stop", function () {
             const blob = new Blob(cameraChunks, { type: cameraRecorder.mimeType });
 
             // Pass video data to Electron as a base64 encoded string
             const reader = new FileReader();
             reader.readAsDataURL(blob);
-            reader.onloadend = () => window.electronAPI.saveVideo(reader.result);
+            reader.onloadend = function () {
+              window.electronAPI.saveVideo(reader.result);
+            };
           });
         },
-        on_load: () => {
+        on_load: function () {
           // Assign camera feed to the <video> element
           const camera = document.getElementById("webcam");
 
           camera.srcObject = jsPsych.pluginAPI.getCameraRecorder().stream;
         },
-        on_finish: () => {
+        on_finish: function () {
           // Begin video recording
           jsPsych.pluginAPI.getCameraRecorder().start();
         },
@@ -98,7 +100,7 @@ export function buildCameraEndTrial(jsPsych) {
     // TODO #372: Show photodiodeGhostBox as prompt
     stimulus: div(recordingEndMarkup, { class: "bottom-prompt" }),
     trial_duration: 5000,
-    on_start: () => {
+    on_start: function () {
       // Complete the camera recording
 
       if (!config.USE_ELECTRON) {

--- a/src/experiment/trials/fixation.js
+++ b/src/experiment/trials/fixation.js
@@ -19,12 +19,12 @@ export function buildFixationTrial(jsPsych) {
     choices: "NO_KEYS",
     // Display the fixation dot
     stimulus: div("", { id: "fixation-dot" }),
-    prompt: () => {
+    prompt: function () {
       // Conditionally display the photodiodeGhostBox
       if (config.USE_PHOTODIODE) return photodiodeGhostBox;
       else return null;
     },
-    trial_duration: () => {
+    trial_duration: function () {
       if (fixationSettings.randomize_duration) {
         // Select a random duration from the durations array to show the fixation dot for
         return jsPsych.randomization.sampleWithoutReplacement(fixationSettings.durations, 1)[0];
@@ -36,7 +36,7 @@ export function buildFixationTrial(jsPsych) {
     data: {
       code: fixationCode, // Add event code to the recorded data
     },
-    on_load: () => {
+    on_load: function () {
       // Conditionally flash the photodiode when the trial first loads
       if (config.USE_PHOTODIODE) pdSpotEncode(fixationCode);
     },

--- a/src/experiment/trials/holdUpMarker.js
+++ b/src/experiment/trials/holdUpMarker.js
@@ -9,13 +9,13 @@ import { div, h1, p } from "../../lib/markup/tags";
 // TODO #330: Actually check to see if USB is connected? This isn't testing anything?
 export const holdUpMarkerTrial = {
   type: htmlButtonResponse,
-  stimulus: () => {
+  stimulus: function () {
     const eventMarkerMarkup = h1(LANGUAGE.trials.eventMarker.connected, {
       style: "color: green;",
     });
     return div(eventMarkerMarkup, { class: "bottom-prompt" });
   },
-  prompt: () => {
+  prompt: function () {
     let holdUpMarkerPrompt = p(LANGUAGE.trials.holdUpMarker);
 
     // Conditionally add the photodiodeGhostBox
@@ -24,7 +24,7 @@ export const holdUpMarkerTrial = {
     return holdUpMarkerPrompt;
   },
   choices: [LANGUAGE.prompts.continue.button],
-  on_load: () => {
+  on_load: function () {
     // Conditionally flash the photodiode when the trial first loads
     if (config.USE_PHOTODIODE) pdSpotEncode(eventCodes.test_connect);
   },

--- a/src/experiment/trials/introduction.js
+++ b/src/experiment/trials/introduction.js
@@ -7,7 +7,7 @@ import { div, h1 } from "../../lib/markup/tags";
 export const introductionTrial = {
   type: htmlKeyboardResponse,
   response_ends_trial: true,
-  stimulus: () => {
+  stimulus: function () {
     const welcomeMarkup = h1(LANGUAGE.trials.welcome);
     return div(welcomeMarkup, { class: "bottom-prompt" });
   },

--- a/src/experiment/trials/startCode.js
+++ b/src/experiment/trials/startCode.js
@@ -13,13 +13,13 @@ export const startCodeTrial = {
   stimulus: "assets/audio/beep.mp3",
   choices: "NO_KEYS",
   trial_ends_after_audio: true,
-  prompt: () => {
+  prompt: function () {
     let markup = h1(LANGUAGE.prompts.settingUp);
     // Conditionally displays the photodiodeGhostBox
     if (config.USE_PHOTODIODE) markup += photodiodeGhostBox;
     return markup;
   },
-  on_load: () => {
+  on_load: function () {
     // Conditionally flashes the photodiode when the trial first loads
     if (config.USE_PHOTODIODE) pdSpotEncode(eventCodes.open_task);
   },

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -53,26 +53,6 @@ export function formatDollars(amount) {
 }
 
 /**
- * Starts the JsPsych keyboard response listener
- * @param  jsPsych The jsPsych instance running the task.
- */
-// TODO: Remove?
-export function startKeypressListener(jsPsych) {
-  const keypressResponse = (info) => {
-    const data = { key_press: info.key };
-    jsPsych.finishTrial(data);
-  };
-
-  const keyboardListener = jsPsych.pluginAPI.getKeyboardResponse({
-    callback_function: keypressResponse,
-    valid_responses: ["ALL_KEYS"],
-    persist: false,
-  });
-
-  return keyboardListener;
-}
-
-/**
  * Gets the value of a given variable from the URL search parameters
  * @param {string} queryParameter The key of the variable in the search parameters
  * @returns {string} The value of variable in the search parameters

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -56,6 +56,7 @@ export function formatDollars(amount) {
  * Starts the JsPsych keyboard response listener
  * @param  jsPsych The jsPsych instance running the task.
  */
+// TODO: Remove?
 export function startKeypressListener(jsPsych) {
   const keypressResponse = (info) => {
     const data = { key_press: info.key };


### PR DESCRIPTION
The [jsPsych documentation](https://www.jspsych.org/7.3/overview/events/) always uses the function syntax instead of arrow functions. It's a little more complicated code but I think matching the documentation will be better for folks. 

- Refactors the arrow functions for the event related callbacks to use `function(){}` syntax
- Removes `startKeypressListener` utility function as it's unused
