### PR TITLE
build: Update Electron dependency and fix writeable stream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "cross-env": "^7.0.3",
         "cz-conventional-changelog": "^3.2.0",
         "dotenv-cli": "^7.0.0",
-        "electron": "^27.0.1",
+        "electron": "^28.2.1",
         "eslint": "^8.54.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-import": "^2.29.0",
@@ -12812,9 +12812,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-27.3.1.tgz",
-      "integrity": "sha512-hDAeaTJvXHu3vCmR6l6/muPGaKRlEp6v471yyqOju9xhLKUaGOAdMN46F0V+SCABZq2nWr9DTwqHsJ0b4hUZLQ==",
+      "version": "28.2.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-28.2.1.tgz",
+      "integrity": "sha512-wlzXf+OvOiVlBf9dcSeMMf7Q+N6DG+wtgFbMK0sA/JpIJcdosRbLMQwLg/LTwNVKIbmayqFLDp4FmmFkEMhbYA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "cross-env": "^7.0.3",
     "cz-conventional-changelog": "^3.2.0",
     "dotenv-cli": "^7.0.0",
-    "electron": "^27.0.1",
+    "electron": "^28.2.1",
     "eslint": "^8.54.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-import": "^2.29.0",

--- a/public/electron/main.js
+++ b/public/electron/main.js
@@ -27,8 +27,6 @@ let CONFIG; // Honeycomb configuration object
 let DEV_MODE; // Whether or not the application is running in dev mode
 
 let TEMP_FILE; // Path to the temporary output file
-// TODO: Delete, save temp file path?
-// let WRITE_STREAM; // Writeable file stream for the data (in the user's appData folder)
 let OUT_PATH; // Path to the final output folder (on the Desktop)
 let OUT_FILE; // Name of the final output file
 
@@ -191,11 +189,14 @@ function handleOnDataUpdate(event, data) {
     fs.mkdirSync(tempPath, { recursive: true });
     TEMP_FILE = path.resolve(tempPath, OUT_FILE);
 
-    fs.appendFileSync(TEMP_FILE, "{"); // Write initial bracket
+    // Write initial bracket
+    fs.appendFileSync(TEMP_FILE, "{");
     log.info("Temporary file created at ", TEMP_FILE);
+
+    // Write useful information and the beginning of the trials array
     fs.appendFileSync(TEMP_FILE, `"start_time": "${start_date}",`);
     fs.appendFileSync(TEMP_FILE, `"git_version": ${JSON.stringify(GIT_VERSION)},`);
-    fs.appendFileSync(TEMP_FILE, `"trials": [`); // Begin writing trials array
+    fs.appendFileSync(TEMP_FILE, `"trials": [`);
   }
 
   // Prepend comma for all trials except first

--- a/public/electron/main.js
+++ b/public/electron/main.js
@@ -201,6 +201,7 @@ function handleOnDataUpdate(event, data) {
 
   // Prepend comma for all trials except first
   if (trial_index > 0) fs.appendFileSync(TEMP_FILE, ",");
+
   // Write trial data
   fs.appendFileSync(TEMP_FILE, JSON.stringify(data));
 

--- a/public/electron/main.js
+++ b/public/electron/main.js
@@ -173,7 +173,7 @@ function handlePhotodiodeTrigger(event, code) {
 function handleOnDataUpdate(event, data) {
   const { participant_id, study_id, start_date, trial_index } = data;
 
-  // Set the output path and file name if they haven't been
+  // Set the output path and file name if they are not set yet
   if (!OUT_PATH) {
     // The final OUT_FILE will be nested inside subfolders on the Desktop
     OUT_PATH = path.resolve(app.getPath("desktop"), app.getName(), study_id, participant_id);

--- a/public/electron/main.js
+++ b/public/electron/main.js
@@ -85,13 +85,13 @@ app.on("before-quit", () => {
     JSON.parse(fs.readFileSync(TEMP_FILE));
   } catch (error) {
     if (error instanceof TypeError) {
-      // TypeError because TEMP_FILE is undefined at this point
+      // TEMP_FILE is undefined at this point
       log.warn("Application quit before the participant started the experiment");
     } else if (error instanceof SyntaxError) {
-      // Syntax error because trials are still being written (hasn't hit handleOnFinish function)
+      // Trials are still being written (i.e. hasn't hit handleOnFinish function)
       log.warn("Application quit while the participant was completing the experiment");
     } else {
-      log.error("Electron encountered an error while logging out:");
+      log.error("Electron encountered an error while quitting:");
       log.error(error);
     }
   }

--- a/public/electron/main.js
+++ b/public/electron/main.js
@@ -152,7 +152,7 @@ function handleCheckSerialPort() {
 /**
  * Sends the event_codes to the trigger port
  * @param {} event The serial port event
- * @param {number} code The event code to be recorder
+ * @param {number} code The event code to be recorded
  */
 function handlePhotodiodeTrigger(event, code) {
   if (code !== undefined) {


### PR DESCRIPTION
- Updates `electron` to latest version
- Fixes an issue with the writeable stream by refactoring to `fs.appendFileSync`

Previously the last trial wasn't being written to correctly because the stream was "immediately" being used to append the closing `]}`. This is done synchronously down so it fixes the issue. I also cleanup up some of the logic for when a user quits the application before completing the experiment

closes #399 