### PR TITLE
ref: Refer to blocks as procedures

### DIFF
--- a/src/experiment/honeycomb.js
+++ b/src/experiment/honeycomb.js
@@ -1,6 +1,6 @@
-import { buildEndBlock } from "./blocks/endBlock";
-import { buildHoneycombBlock } from "./blocks/honeycombBlock";
-import { buildStartBlock } from "./blocks/startBlock";
+import { buildEndProcedure } from "./procedures/endProcedure";
+import { buildHoneycombProcedure } from "./procedures/honeycombProcedure";
+import { buildStartProcedure } from "./procedures/startProcedure";
 
 import { buildDebriefTrial, instructionsTrial, preloadTrial } from "./trials/honeycombTrials";
 
@@ -28,25 +28,25 @@ export const honeycombOptions = {
  * @returns {Object} A jsPsych timeline object
  */
 export function buildHoneycombTimeline(jsPsych) {
-  // Build the trials that make up the start block
-  const startBlock = buildStartBlock(jsPsych);
+  // Build the trials that make up the start procedure
+  const startProcedure = buildStartProcedure(jsPsych);
 
-  // Build the trials that make up the Honeycomb block
-  const honeycombBlock = buildHoneycombBlock(jsPsych);
+  // Build the trials that make up the task procedure
+  const honeycombProcedure = buildHoneycombProcedure(jsPsych);
 
   // Builds the trial needed to debrief the participant on their performance
   const debriefTrial = buildDebriefTrial(jsPsych);
 
-  // Builds the trials that make up the end block
-  const endBlock = buildEndBlock(jsPsych);
+  // Builds the trials that make up the end procedure
+  const endProcedure = buildEndProcedure(jsPsych);
 
   const timeline = [
-    startBlock,
+    startProcedure,
     preloadTrial,
     instructionsTrial,
-    honeycombBlock,
+    honeycombProcedure,
     debriefTrial,
-    endBlock,
+    endProcedure,
   ];
   return timeline;
 }

--- a/src/experiment/procedures/endProcedure.js
+++ b/src/experiment/procedures/endProcedure.js
@@ -4,24 +4,24 @@ import { conclusionTrial } from "../trials/conclusion";
 import { exitFullscreenTrial } from "../trials/fullscreen";
 
 /**
- * Builds the block of trials needed to end the experiment
+ * Builds the procedure needed to end the experiment
  * 1) Trial used to complete the user's camera recording is displayed
  * 2) The experiment exits fullscreen
  *
  * @param {Object} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych (nested) timeline object
  */
-export function buildEndBlock(jsPsych) {
-  const endBlock = [];
+export function buildEndProcedure(jsPsych) {
+  const procedure = [];
 
   // Conditionally add the camera breakdown trials
   if (config.USE_CAMERA) {
-    endBlock.push(buildCameraEndTrial(jsPsych));
+    procedure.push(buildCameraEndTrial(jsPsych));
   }
 
   // Add the other trials needed to end the experiment
-  endBlock.push(exitFullscreenTrial, conclusionTrial);
+  procedure.push(exitFullscreenTrial, conclusionTrial);
 
   // Return the block as a nested timeline
-  return { timeline: endBlock };
+  return { timeline: procedure };
 }

--- a/src/experiment/procedures/honeycombProcedure.js
+++ b/src/experiment/procedures/honeycombProcedure.js
@@ -15,7 +15,7 @@ import { buildFixationTrial } from "../trials/fixation";
  * @param {Object} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych (nested) timeline object
  */
-export function buildHoneycombBlock(jsPsych) {
+export function buildHoneycombProcedure(jsPsych) {
   const honeycombSettings = SETTINGS.honeycomb;
 
   const fixationTrial = buildFixationTrial(jsPsych);

--- a/src/experiment/procedures/startProcedure.js
+++ b/src/experiment/procedures/startProcedure.js
@@ -18,20 +18,20 @@ import { introductionTrial } from "../trials/introduction";
  * @param {Object} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych (nested) timeline object
  */
-export function buildStartBlock(jsPsych) {
-  const startBlock = [nameTrial, enterFullscreenTrial, introductionTrial];
+export function buildStartProcedure(jsPsych) {
+  const procedure = [nameTrial, enterFullscreenTrial, introductionTrial];
 
   // Conditionally add the photodiode setup trials
   if (config.USE_PHOTODIODE) {
-    startBlock.push(holdUpMarkerTrial);
-    startBlock.push(startCodeTrial);
+    procedure.push(holdUpMarkerTrial);
+    procedure.push(startCodeTrial);
   }
 
   // Conditionally add the camera setup trials
   if (config.USE_CAMERA) {
-    startBlock.push(buildCameraStartTrial(jsPsych));
+    procedure.push(buildCameraStartTrial(jsPsych));
   }
 
   // Return the block as a nested timeline
-  return { timeline: startBlock };
+  return { timeline: procedure };
 }


### PR DESCRIPTION
The jsPsych documentation refers to a collection of trials as a nested timeline as a "procedure." We now use the same word in Honeycomb.

- Renames `blocks/` folderas `procedures/`
- Renames `__Block` as `__Procedure` (file name and the function itself)

closes #409 