### PR TITLE
feat: Specify `on_finish` logic for Firebase and Electron

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,12 +82,12 @@
       }
     },
     "node_modules/@ampproject/remapping": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
-      "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
       "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
       },
       "engines": {
         "node": ">=6.0.0"
@@ -3645,9 +3645,9 @@
       }
     },
     "node_modules/@electron/windows-sign": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.1.1.tgz",
-      "integrity": "sha512-g8/atfOCKuuGedjVE6Xu/rlBtJvfDrmBH9UokBrjrvBVWdVz3SGV7DTjPTLvl7F+XUlmqj4genub62r3jKHIHw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.1.2.tgz",
+      "integrity": "sha512-eXEiZjDtxW3QORCWfRUarANPRTlH9B6At4jqBZJ0NzokSGutXQUVLPA6WmGpIhDW6w2yCMdHW1EJd1HrXtU5sg==",
       "dev": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
@@ -3660,7 +3660,7 @@
         "electron-windows-sign": "bin/electron-windows-sign.js"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -6268,13 +6268,13 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.4.tgz",
-      "integrity": "sha512-Oud2QPM5dHviZNn4y/WhhYKSXksv+1xLEIsNrAbGcFzUN3ubqWRFT5gwPchNc5NuzILOU4tPBDTZ4VwhL8Y7cw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
       "dependencies": {
-        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
+        "@jridgewell/trace-mapping": "^0.3.24"
       },
       "engines": {
         "node": ">=6.0.0"
@@ -6311,9 +6311,9 @@
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.23",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.23.tgz",
-      "integrity": "sha512-9/4foRoUKp8s96tSkh8DlAAc5A0Ty8vLXld+l9gjKKY6ckwI8G15f0hskGmuLZu78ZlGa1vtsfOa+lnB4vG6Jg==",
+      "version": "0.3.24",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.24.tgz",
+      "integrity": "sha512-+VaWXDa6+l6MhflBvVXjIEAzb59nQ2JUK3bwRp2zRpPtU+8TFRy9Gg/5oIcNlkEL5PGlBFGfemUVvIgLnTzq7Q==",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -12964,9 +12964,9 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.687",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.687.tgz",
-      "integrity": "sha512-Ic85cOuXSP6h7KM0AIJ2hpJ98Bo4hyTUjc4yjMbkvD+8yTxEhfK9+8exT2KKYsSjnCn2tGsKVSZwE7ZgTORQCw=="
+      "version": "1.4.689",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.689.tgz",
+      "integrity": "sha512-GatzRKnGPS1go29ep25reM94xxd1Wj8ritU0yRhCJ/tr1Bg8gKnm6R9O/yPOhGQBoLMZ9ezfrpghNaTw97C/PQ=="
     },
     "node_modules/electron-winstaller": {
       "version": "5.2.2",
@@ -16591,9 +16591,9 @@
       }
     },
     "node_modules/heap-js": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/heap-js/-/heap-js-2.3.0.tgz",
-      "integrity": "sha512-E5303mzwQ+4j/n2J0rDvEPBN7GKjhis10oHiYOgjxsmxYgqG++hz9NyLLOXttzH8as/DyiBHYpUrJTZWYaMo8Q==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/heap-js/-/heap-js-2.5.0.tgz",
+      "integrity": "sha512-kUGoI3p7u6B41z/dp33G6OaL7J4DRqRYwVmeIlwLClx7yaaAy7hoDExnuejTKtuDwfcatGmddHDEOjf6EyIxtQ==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -28237,11 +28237,11 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.5.tgz",
-      "integrity": "sha512-QcgiIWV4WV7qWExbN5llt6frQB/lBven9pqliLXfGPB+K9ZYXxDozp0wLkHS24kWCm+6YXH/f0HhnObZnZOBnQ==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
       "dependencies": {
-        "call-bind": "^1.0.6",
+        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.4",
         "object-inspect": "^1.13.1"

--- a/public/electron/main.js
+++ b/public/electron/main.js
@@ -226,11 +226,12 @@ function handleOnFinish() {
   try {
     fs.mkdirSync(OUT_PATH, { recursive: true });
     fs.copyFileSync(TEMP_FILE, filePath);
+    log.info("Successfully saved experiment data to ", filePath);
   } catch (e) {
     log.error.error("Unable to save file: ", filePath);
     log.error.error(e);
   }
-  log.info("Successfully saved experiment data to ", filePath);
+  app.quit();
 }
 
 // Save webm video file

--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -113,11 +113,11 @@ export default function App() {
 
   // Default to no operation
   const defaultFunction = () => {};
-  // Add trial data to Firestore
+  // Add trial data to Firestore (see src/App/deployments/firebase.js)
   const firebaseUpdateFunction = (data) => {
     addToFirebase(data);
   };
-  // Execute the 'data' callback function (see public/electron.js)
+  // Execute the 'on_data_update' callback function (see public/electron/main.js)
   const desktopUpdateFunction = async (data) => {
     await window.electronAPI.on_data_update(data);
   };
@@ -130,9 +130,13 @@ export default function App() {
 
   // Save the experiment data on the desktop
   const defaultFinishFunction = (data) => {
-    data.localSave("csv", "neuro-task.csv");
+    data.localSave("csv", "task.csv");
   };
-  // Execute the 'end' callback function (see public/electron.js)
+  // Reload the page
+  const firebaseFinishFunction = () => {
+    window.location.reload();
+  };
+  // Execute the 'on_finish' callback function (see public/electron/main.js)
   const desktopFinishFunction = async () => {
     await window.electronAPI.on_finish();
   };
@@ -178,7 +182,7 @@ export default function App() {
             {
               desktop: desktopFinishFunction,
               mturk: psiturkFinishFunction,
-              firebase: defaultFunction,
+              firebase: firebaseFinishFunction,
               default: defaultFinishFunction,
             }[currentMethod]
           }

--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -132,10 +132,8 @@ export default function App() {
   const defaultFinishFunction = (data) => {
     data.localSave("csv", "task.csv");
   };
-  // Reload the page
-  const firebaseFinishFunction = () => {
-    window.location.reload();
-  };
+  // Do nothing
+  const firebaseFinishFunction = () => {};
   // Execute the 'on_finish' callback function (see public/electron/main.js)
   const desktopFinishFunction = async () => {
     await window.electronAPI.on_finish();

--- a/src/App/components/JsPsychExperiment.jsx
+++ b/src/App/components/JsPsychExperiment.jsx
@@ -31,12 +31,12 @@ export default function JsPsychExperiment({
       ...jsPsychOptions,
       display_element: EXPERIMENT_ID,
       on_data_update: (data) => {
-        dataUpdateFunction(data); // Call Honeycomb's on_data_update function
         jsPsychOptions.on_data_update && jsPsychOptions.on_data_update(data); // Call custom on_data_update function (if provided)
+        dataUpdateFunction(data); // Call Honeycomb's on_data_update function
       },
       on_finish: (data) => {
-        dataFinishFunction(data); // Call Honeycomb's on_finish function
         jsPsychOptions.on_finish && jsPsychOptions.on_finish(data); // Call custom on_finish function (if provided)
+        dataFinishFunction(data); // Call Honeycomb's on_finish function
       },
     });
 

--- a/src/App/components/JsPsychExperiment.jsx
+++ b/src/App/components/JsPsychExperiment.jsx
@@ -31,12 +31,12 @@ export default function JsPsychExperiment({
       ...jsPsychOptions,
       display_element: EXPERIMENT_ID,
       on_data_update: (data) => {
-        jsPsychOptions.on_data_update && jsPsychOptions.on_data_update(data); // Call custom on_data_update function (if provided)
         dataUpdateFunction(data); // Call Honeycomb's on_data_update function
+        jsPsychOptions.on_data_update && jsPsychOptions.on_data_update(data); // Call custom on_data_update function (if provided)
       },
       on_finish: (data) => {
-        jsPsychOptions.on_finish && jsPsychOptions.on_finish(data); // Call custom on_finish function (if provided)
         dataFinishFunction(data); // Call Honeycomb's on_finish function
+        jsPsychOptions.on_finish && jsPsychOptions.on_finish(data); // Call custom on_finish function (if provided)
       },
     });
 

--- a/src/experiment/honeycomb.js
+++ b/src/experiment/honeycomb.js
@@ -14,6 +14,11 @@ import { buildDebriefTrial, instructionsTrial, preloadTrial } from "./trials/hon
  * Note that Honeycomb combines these with other options required for Honeycomb to operate correctly
  */
 export const honeycombOptions = {
+  // Called when every trial finishes
+  on_trial_finish: function (data) {
+    console.log(`Trial ${data.internal_node_id} just finished:`, data);
+  },
+  // Called when the experiment finishes
   on_finish: function (data) {
     console.log("The experiment has finished:", data);
   },

--- a/src/experiment/honeycomb.js
+++ b/src/experiment/honeycomb.js
@@ -21,6 +21,8 @@ export const honeycombOptions = {
   // Called when the experiment finishes
   on_finish: function (data) {
     console.log("The experiment has finished:", data);
+    // Reload the page for another run-through of the experiment
+    window.location.reload();
   },
 };
 

--- a/src/experiment/index.js
+++ b/src/experiment/index.js
@@ -15,12 +15,7 @@ import "../lib/markup/trials.css";
  *
  * Custom options for your experiment should be added in your own file inside the experiment folder
  */
-export const jsPsychOptions = {
-  ...honeycombOptions,
-  on_trial_finish: function (data) {
-    console.log(`Trial ${data.internal_node_id} just finished:`, data);
-  },
-};
+export const jsPsychOptions = honeycombOptions;
 
 /**
  * Builds the experiment's timeline that jsPsych will run


### PR DESCRIPTION
- Electron: The app quits
    - This takes place after the data finishes saving to the desktop
    - _Note that this was default functionality but had been removed at some point. Since the app is run in fullscreen it makes sense that it should just quit once it's done_
- Firebase: Do nothing
    - I did some testing with the [prolific redirect](https://www.jspsych.org/7.3/overview/prolific/#automatically-redirect) example and it doesn't work with the `firebaseFinishFunction` I defined in `App.jsx`.
- `on_finish` option (for Honeycomb) now reloads the page as a default example
- Moves the `on_trial_finish` logic directly into the `honeycomb` file to better specify that it's just an example callback function