### PR TITLE
ref: Rename `DEV_MODE` as `CONTINUE_ANYWAY`

### DIFF
--- a/public/electron/main.js
+++ b/public/electron/main.js
@@ -25,8 +25,7 @@ log.initialize({ preload: true });
 /************ GLOBALS ***********/
 
 const GIT_VERSION = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../version.json")));
-
-// TODO @brown-ccv #443 : Use NODE_ENV here for dev vs production
+// TODO @brown-ccv #436 : Use app.isPackaged() to determine if running in dev or prod
 const ELECTRON_START_URL = process.env.ELECTRON_START_URL;
 
 let CONFIG; // Honeycomb configuration object

--- a/public/electron/main.js
+++ b/public/electron/main.js
@@ -25,8 +25,8 @@ log.initialize({ preload: true });
 /************ GLOBALS ***********/
 
 let CONFIG; // Honeycomb configuration object
-// TODO @brown-ccv #428: Rename, this is running in development AND user hit "Continue Anyway"
-let DEV_MODE; // Whether or not the application is running in dev mode
+// let CONTINUE_ANYWAY; // Whether or not the application is running in dev mode
+let CONTINUE_ANYWAY; // true if in dev mode and the user elects "continue anyway"
 
 let TEMP_FILE; // Path to the temporary output file
 let OUT_PATH; // Path to the final output folder (on the Desktop)
@@ -314,7 +314,6 @@ function createWindow() {
   mainWindow.loadURL(appURL);
 }
 
-
 /** SERIAL PORT SETUP & COMMUNICATION (EVENT MARKER) */
 
 /**
@@ -363,7 +362,7 @@ async function setUpPort() {
             app.exit();
           } else {
             // User selected "Continue Anyway", we must be in dev mode
-            DEV_MODE = true;
+            CONTINUE_ANYWAY = true;
             TRIGGER_PORT = undefined;
           }
         });
@@ -383,7 +382,7 @@ function handleEventSend(code) {
   log.info(`Sending USB event ${code} to port ${TRIGGER_PORT}`);
 
   // Early return when running in development (no trigger port is expected)
-  if (DEV_MODE) return;
+  if (CONTINUE_ANYWAY) return;
 
   if (TRIGGER_PORT !== undefined) {
     sendToPort(TRIGGER_PORT, code);
@@ -415,7 +414,7 @@ function handleEventSend(code) {
         break;
       case 2:
         // User selects "Continue Anyway", we must be in dev mode
-        DEV_MODE = true;
+        CONTINUE_ANYWAY = true;
         break;
     }
   }

--- a/public/electron/main.js
+++ b/public/electron/main.js
@@ -361,7 +361,7 @@ async function setUpPort() {
             // Quit app when user selects "OK"
             app.exit();
           } else {
-            // User selected "Continue Anyway", we must be in dev mode
+            // User selected "Continue Anyway", trigger port is not connected
             CONTINUE_ANYWAY = true;
             TRIGGER_PORT = undefined;
           }

--- a/public/electron/main.js
+++ b/public/electron/main.js
@@ -24,9 +24,9 @@ log.initialize({ preload: true });
 
 /************ GLOBALS ***********/
 
+// TODO @brown-ccv #443 : Use NODE_ENV here for dev vs production
 let CONFIG; // Honeycomb configuration object
-// let CONTINUE_ANYWAY; // Whether or not the application is running in dev mode
-let CONTINUE_ANYWAY; // true if in dev mode and the user elects "continue anyway"
+let CONTINUE_ANYWAY; // Whether to continue the experiment with no hardware connected (option is only available in dev mode)
 
 let TEMP_FILE; // Path to the temporary output file
 let OUT_PATH; // Path to the final output folder (on the Desktop)

--- a/public/electron/main.js
+++ b/public/electron/main.js
@@ -24,7 +24,11 @@ log.initialize({ preload: true });
 
 /************ GLOBALS ***********/
 
+const GIT_VERSION = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../version.json")));
+
 // TODO @brown-ccv #443 : Use NODE_ENV here for dev vs production
+const ELECTRON_START_URL = process.env.ELECTRON_START_URL;
+
 let CONFIG; // Honeycomb configuration object
 let CONTINUE_ANYWAY; // Whether to continue the experiment with no hardware connected (option is only available in dev mode)
 
@@ -34,8 +38,6 @@ let OUT_FILE; // Name of the final output file
 
 let TRIGGER_CODES; // Trigger codes and IDs for the EEG machine
 let TRIGGER_PORT; // Port that the EEG machine is talking through
-
-const GIT_VERSION = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../version.json")));
 
 /************ APP LIFECYCLE ***********/
 
@@ -269,11 +271,11 @@ function createWindow() {
   let mainWindow;
   let appURL;
 
-  if (process.env.ELECTRON_START_URL) {
+  if (ELECTRON_START_URL) {
     // Running in development
 
     // Load app from localhost (This allows hot-reloading)
-    appURL = process.env.ELECTRON_START_URL;
+    appURL = ELECTRON_START_URL;
 
     // Create a 1500x900 window with the dev tools open
     mainWindow = new BrowserWindow({
@@ -351,7 +353,7 @@ async function setUpPort() {
           buttons: [
             "OK",
             // Allow continuation when running in development mode
-            ...(process.env.ELECTRON_START_URL ? ["Continue Anyway"] : []),
+            ...(ELECTRON_START_URL ? ["Continue Anyway"] : []),
           ],
           defaultId: 0,
         })
@@ -398,7 +400,7 @@ function handleEventSend(code) {
         "Quit",
         "Retry",
         // Allow continuation when running in development mode
-        ...(process.env.ELECTRON_START_URL ? ["Continue Anyway"] : []),
+        ...(ELECTRON_START_URL ? ["Continue Anyway"] : []),
       ],
       detail: "heres some detail",
     });

--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -58,6 +58,7 @@ export default function App() {
 
       // If on desktop
       if (config.USE_ELECTRON) {
+        // TODO @brown-ccv #443 : Pass NODE_ENV here as well
         await window.electronAPI.setConfig(config); // Pass config to Electron ipcMain
         await window.electronAPI.setTrigger(trigger); // Pass trigger to Electron ipcMain
 


### PR DESCRIPTION
The `DEV_MODE` flag is only true when the user elects "continue anyway" (e.g. for testing an experiment without the hardware explicitly connected. The rename to `CONTINUE_ANYWAY` better indicates the state of the application though

- Renames `DEV_MODE` as `CONTINUE_URL`
- Pulls `process.env.ELECTRON_START_URL` into its own variable