### PR TITLE
fix: Add serialport code as its own file again

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -45,10 +45,9 @@ export default {
       config: {
         build: [
           // Build files that use the main config
-          // TODO: Add serialPort.js here
           { entry: "src/electron/main.js", config: "vite.main.config.js" },
           // Build files that use the preload config
-          { entry: "src/electron/preload.js", config: "vite.preload.config.js" },
+          { entry: "src/Electron/preload.js", config: "vite.preload.config.js" },
         ],
         renderer: [{ name: "main_window", config: "vite.renderer.config.js" }],
       },

--- a/src/Electron/lib/serialport.js
+++ b/src/Electron/lib/serialport.js
@@ -1,0 +1,64 @@
+import SerialPort from "serialport";
+
+// TODO @brown-ccv #460: Test connections with MockBindings (e.g. CONTINUE_ANYWAY)  https://serialport.io/docs/api-binding-mock
+
+/**
+ * Retrieve's a serial port device based on either the COM name or product identifier
+ * If productID is undefined then comVendorName is the COM name, otherwise it's the vendorID
+ * @param {Array} portList A list of available serial port devices
+ * @param {string} comVendorName EITHER a com name or the vendor identifier of the desired device
+ * @param {string | undefined} productId The product identifier of the desired device
+ * @returns The SerialPort device
+ */
+function getDevice(portList, comVendorName, productId) {
+  if (productId === undefined) {
+    const comName = comVendorName;
+    return portList.filter(
+      // Find the device with the matching comName
+      (device) => device.comName === comName.toUpperCase() || device.comName === comName
+    );
+  } else {
+    const vendorId = comVendorName;
+    return portList.filter(
+      // Find the device with the matching vendorId and productId
+      (device) =>
+        (device.vendorId === vendorId.toUpperCase() || device.vendorId === vendorId) &&
+        device.productId === productId
+    );
+  }
+}
+
+/**
+ * Retrieve's a serial port device based on either the COM name or product identifier
+ * Returns false if the desired device was not found
+ * @param {string} comVendorName EITHER a com name or the vendor identifier of the desired device
+ * @param {string | undefined} productId The product identifier of the desired device
+ * @returns The SerialPort device
+ */
+// TODO @brown-ccv #460: This should fail, not return false
+export async function getPort(comVendorName, productId) {
+  let portList;
+  try {
+    portList = await SerialPort.list();
+  } catch {
+    return false;
+  }
+
+  const device = getDevice(portList, comVendorName, productId);
+  try {
+    const path = device[0].comName;
+    const port = new SerialPort(path);
+    return port;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Sends event code data to a serial port device
+ * @param {SerialPort} port A SerialPort device
+ * @param {number} event_code The numeric code to write to the device
+ */
+export async function sendToPort(port, event_code) {
+  port.write(Buffer.from([event_code]));
+}

--- a/src/Electron/main.js
+++ b/src/Electron/main.js
@@ -6,10 +6,7 @@ import { app, BrowserWindow, ipcMain, dialog } from "electron";
 import log from "electron-log";
 import _ from "lodash";
 
-// TODO @RobertGemmaJr: Figure out how to install the dev tools
-// import installExtension, { REACT_DEVELOPER_TOOLS } from 'electron-devtools-installer';
-
-// const { getPort, sendToPort } = require("./serialPort");
+import { getPort, sendToPort } from "./lib/serialport";
 
 // TODO @RobertGemmaJr: Do more testing with the environment variables - are home/clinic being built correctly?
 // TODO @brown-ccv #460: Add serialport's MockBinding for the "Continue Anyway": https://serialport.io/docs/guide-testing
@@ -451,71 +448,4 @@ function handleEventSend(code) {
         break;
     }
   }
-}
-
-// TODO: SERPATE SERIAL PORT FILE
-
-const SerialPort = require("serialport");
-
-// TODO @brown-ccv #460: Test connections with MockBindings (e.g. CONTINUE_ANYWAY)  https://serialport.io/docs/api-binding-mock
-
-/**
- * Retrieve's a serial port device based on either the COM name or product identifier
- * If productID is undefined then comVendorName is the COM name, otherwise it's the vendorID
- * @param {Array} portList A list of available serial port devices
- * @param {string} comVendorName EITHER a com name or the vendor identifier of the desired device
- * @param {string | undefined} productId The product identifier of the desired device
- * @returns The SerialPort device
- */
-function getDevice(portList, comVendorName, productId) {
-  if (productId === undefined) {
-    const comName = comVendorName;
-    return portList.filter(
-      // Find the device with the matching comName
-      (device) => device.comName === comName.toUpperCase() || device.comName === comName
-    );
-  } else {
-    const vendorId = comVendorName;
-    return portList.filter(
-      // Find the device with the matching vendorId and productId
-      (device) =>
-        (device.vendorId === vendorId.toUpperCase() || device.vendorId === vendorId) &&
-        device.productId === productId
-    );
-  }
-}
-
-/**
- * Retrieve's a serial port device based on either the COM name or product identifier
- * Returns false if the desired device was not found
- * @param {string} comVendorName EITHER a com name or the vendor identifier of the desired device
- * @param {string | undefined} productId The product identifier of the desired device
- * @returns The SerialPort device
- */
-// TODO @brown-ccv #460: This should fail, not return false
-async function getPort(comVendorName, productId) {
-  let portList;
-  try {
-    portList = await SerialPort.list();
-  } catch {
-    return false;
-  }
-
-  const device = getDevice(portList, comVendorName, productId);
-  try {
-    const path = device[0].comName;
-    const port = new SerialPort(path);
-    return port;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Sends event code data to a serial port device
- * @param {SerialPort} port A SerialPort device
- * @param {number} event_code The numeric code to write to the device
- */
-async function sendToPort(port, event_code) {
-  port.write(Buffer.from([event_code]));
 }


### PR DESCRIPTION
Moves the serial port code back into its own file (`/lib/serialport.js`). 

Note that based on the current `forge.config.js` vite will build the serial port code into its own file. I could add it as a separate file in the config (and vite would build them separately) but I think  it's totally fine as is.