### PR TITLE
feat: add sample countdown trial that counts down before the start of…

### DIFF
--- a/src/experiment/honeycomb.js
+++ b/src/experiment/honeycomb.js
@@ -3,6 +3,7 @@ import { buildHoneycombProcedure } from "./procedures/honeycombProcedure";
 import { buildStartProcedure } from "./procedures/startProcedure";
 
 import { buildDebriefTrial, instructionsTrial, preloadTrial } from "./trials/honeycombTrials";
+import { buildCountdownTrial } from "./trials/countdown";
 
 /**
  * ! This file should not be edited! Instead, create a new file with the name of your task
@@ -47,8 +48,12 @@ export function buildHoneycombTimeline(jsPsych) {
   // Builds the trials that make up the end procedure
   const endProcedure = buildEndProcedure(jsPsych);
 
+  // Builds a countdown trial that counts down for 6000ms
+  const countdownTrial = buildCountdownTrial(6000);
+
   const timeline = [
     startProcedure,
+    countdownTrial,
     preloadTrial,
     instructionsTrial,
     honeycombProcedure,

--- a/src/experiment/honeycomb.js
+++ b/src/experiment/honeycomb.js
@@ -48,8 +48,8 @@ export function buildHoneycombTimeline(jsPsych) {
   // Builds the trials that make up the end procedure
   const endProcedure = buildEndProcedure(jsPsych);
 
-  // Builds a countdown trial that counts down for 6000ms
-  const countdownTrial = buildCountdownTrial(6000);
+  // Builds a countdown trial that counts down for 3000ms
+  const countdownTrial = buildCountdownTrial(3000);
 
   const timeline = [
     startProcedure,

--- a/src/experiment/trials/countdown.js
+++ b/src/experiment/trials/countdown.js
@@ -4,7 +4,7 @@ import { h1 } from "../../lib/markup/tags";
 /**
  * Returns millisecond to minute
  *
- * @param {*} ms - millisecond
+ * @param {number} ms - millisecond
  * @returns minute value
  */
 function getMinute(ms) {
@@ -14,8 +14,8 @@ function getMinute(ms) {
 /**
  * Given total minute and total millisecond, return the seconds
  *
- * @param {*} ms - millisecond
- * @param {*} min - minute
+ * @param {number} ms - millisecond
+ * @param {number} min - minute
  * @returns the seconds in number
  */
 function getSeconds(ms, min) {
@@ -25,7 +25,7 @@ function getSeconds(ms, min) {
 /**
  * Gets a time in string format to display on screen
  *
- * @param {*} ms - millisecond
+ * @param {number} ms - millisecond
  * @returns return time string format as in 00:00
  */
 function getTimeString(ms) {
@@ -35,11 +35,10 @@ function getTimeString(ms) {
 /**
  * a sample countdown trial that counts down ms before another trial begins
  *
- * @param {*} ms - millisecond to countdown
+ * @param {number} ms - millisecond to countdown
  * @returns a JS object as a trial
  */
-export function buildCountdownTrial(ms) {
-  const waitTime = ms;
+export function buildCountdownTrial(waitTime) {
   return {
     type: htmlKeyboardResponse,
     stimulus:

--- a/src/experiment/trials/countdown.js
+++ b/src/experiment/trials/countdown.js
@@ -1,0 +1,64 @@
+import htmlKeyboardResponse from "@jspsych/plugin-html-keyboard-response";
+import { h1 } from "../../lib/markup/tags";
+
+/**
+ * Returns millisecond to minute
+ *
+ * @param {*} ms - millisecond
+ * @returns minute value
+ */
+function getMinute(ms) {
+  return Math.floor(ms / 1000 / 60);
+}
+
+/**
+ * Given total minute and total millisecond, return the seconds
+ *
+ * @param {*} ms - millisecond
+ * @param {*} min - minute
+ * @returns the seconds in number
+ */
+function getSeconds(ms, min) {
+  return Math.floor((ms - min * 1000 * 60) / 1000);
+}
+
+/**
+ * Gets a time in string format to display on screen
+ *
+ * @param {*} ms - millisecond
+ * @returns return time string format as in 00:00
+ */
+function getTimeString(ms) {
+  return `${getMinute(ms)}:${getSeconds(ms, getMinute(ms)).toString().padStart(2, "0")}`;
+}
+
+/**
+ * a sample countdown trial that counts down ms before another trial begins
+ *
+ * @param {*} ms - millisecond to countdown
+ * @returns a JS object as a trial
+ */
+export function buildCountdownTrial(ms) {
+  const waitTime = ms;
+  return {
+    type: htmlKeyboardResponse,
+    stimulus:
+      h1("The next part of the experiment will start in") +
+      h1(getTimeString(waitTime), {
+        id: "clock",
+      }),
+    choices: "NO_KEYS",
+    trial_duration: waitTime + 20,
+    on_load: function () {
+      const startTime = performance.now();
+      const interval = setInterval(function () {
+        const timeLeft = waitTime - (performance.now() - startTime);
+        document.querySelector("#clock").innerHTML = getTimeString(timeLeft);
+        if (timeLeft <= 0) {
+          document.querySelector("#clock").innerHTML = "0:00";
+          clearInterval(interval);
+        }
+      }, 250);
+    },
+  };
+}

--- a/src/experiment/trials/countdown.js
+++ b/src/experiment/trials/countdown.js
@@ -1,36 +1,6 @@
 import htmlKeyboardResponse from "@jspsych/plugin-html-keyboard-response";
 import { h1 } from "../../lib/markup/tags";
-
-/**
- * Returns millisecond to minute
- *
- * @param {number} ms - millisecond
- * @returns minute value
- */
-function getMinute(ms) {
-  return Math.floor(ms / 1000 / 60);
-}
-
-/**
- * Given total minute and total millisecond, return the seconds
- *
- * @param {number} ms - millisecond
- * @param {number} min - minute
- * @returns the seconds in number
- */
-function getSeconds(ms, min) {
-  return Math.floor((ms - min * 1000 * 60) / 1000);
-}
-
-/**
- * Gets a time in string format to display on screen
- *
- * @param {number} ms - millisecond
- * @returns return time string format as in 00:00
- */
-function getTimeString(ms) {
-  return `${getMinute(ms)}:${getSeconds(ms, getMinute(ms)).toString().padStart(2, "0")}`;
-}
+import { getTimeString } from "../../lib/utils";
 
 /**
  * a sample countdown trial that counts down ms before another trial begins

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -81,3 +81,33 @@ export function getProlificId() {
 export function interleave(arr, val, addBefore = true) {
   return [].concat(...arr.map((n) => (addBefore ? [val, n] : [n, val])));
 }
+
+/**
+ * Given a millisecond value, returns how many full minutes there are (rounding down)
+ *
+ * @param {number} ms - millisecond
+ * @returns total minutes within the provided ms
+ */
+export function getMinute(ms) {
+  return Math.floor(ms / 1000 / 60);
+}
+
+/**
+ * Given a millisecond value, calculates how many full minutes are within those milliseconds and return the left-over time as the seconds
+ *
+ * @param {number} ms - millisecond
+ * @returns how many seconds are left after excluding the full minutes within the provided ms
+ */
+export function getSeconds(ms) {
+  return Math.floor((ms - getMinute(ms) * 1000 * 60) / 1000);
+}
+
+/**
+ * Gets the time (millisecond) in string format to display on screen
+ *
+ * @param {number} ms - millisecond
+ * @returns return time string format, example: 00:03 (min:seconds)
+ */
+export function getTimeString(ms) {
+  return `${getMinute(ms)}:${getSeconds(ms).toString().padStart(2, "0")}`;
+}


### PR DESCRIPTION
- add example `countdown` trial in `trials` folder inside honeycomb for counting down given millisecond (ms) before another trial begins: 
  - in `src/experiment/trials/countdown.js`: 
       - helper functions to convert ms to minutes and seconds to format a time string (00:00) 
       - `buildCountdownTrial` function to return the actual JS trial object that counts down and updates the time string every few ms until counted down to 0 
   - in `src/experiment/honeycomb.js`: an example usage of the `countdown` trial to countdown 6000ms and inserted in the experiment timeline