### PR TITLE
feat: add typedef.js in lib and update documentation in index.js to r…

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,7 @@ module.exports = {
     jsdoc: {
       tagNamePreference: {
         typedef: {
-          definedInFiles: ["src/lib/typedefs.js"],
+          definedInFiles: ["src/lib/typedef.js"],
         },
       },
     },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,13 @@ module.exports = {
     react: {
       version: "detect",
     },
+    jsdoc: {
+      tagNamePreference: {
+        typedef: {
+          definedInFiles: ["src/lib/typedefs.js"],
+        },
+      },
+    },
     "import/resolver": {
       node: {
         extensions: [".js", ".jsx"],

--- a/src/experiment/honeycomb.js
+++ b/src/experiment/honeycomb.js
@@ -1,11 +1,9 @@
-import * as Types from "../lib/typedef";
 import { buildEndProcedure } from "./procedures/endProcedure";
 import { buildHoneycombProcedure } from "./procedures/honeycombProcedure";
 import { buildStartProcedure } from "./procedures/startProcedure";
 
 import { buildDebriefTrial, instructionsTrial, preloadTrial } from "./trials/honeycombTrials";
 import { buildCountdownTrial } from "./trials/countdown";
-
 
 /**
  * ! This file should not be edited! Instead, create a new file with the name of your task
@@ -34,7 +32,7 @@ export const honeycombOptions = {
  * Take a look at how the code here compares to the jsPsych documentation!
  * See the jsPsych documentation for more: https://www.jspsych.org/7.3/tutorials/rt-task/
  *
- * @param {Types.JsPsych} jsPsych The jsPsych instance being used to run the task
+ * @param {JsPsych} jsPsych The jsPsych instance being used to run the task
  * @returns {object} A jsPsych timeline object
  */
 export function buildHoneycombTimeline(jsPsych) {

--- a/src/experiment/honeycomb.js
+++ b/src/experiment/honeycomb.js
@@ -1,3 +1,4 @@
+import { JsPsych } from "jspsych";
 import { buildEndProcedure } from "./procedures/endProcedure";
 import { buildHoneycombProcedure } from "./procedures/honeycombProcedure";
 import { buildStartProcedure } from "./procedures/startProcedure";
@@ -32,8 +33,8 @@ export const honeycombOptions = {
  * Take a look at how the code here compares to the jsPsych documentation!
  * See the jsPsych documentation for more: https://www.jspsych.org/7.3/tutorials/rt-task/
  *
- * @param {Object} jsPsych The jsPsych instance being used to run the task
- * @returns {Object} A jsPsych timeline object
+ * @param {JsPsych} jsPsych The jsPsych instance being used to run the task
+ * @returns {object} A jsPsych timeline object
  */
 export function buildHoneycombTimeline(jsPsych) {
   // Build the trials that make up the start procedure

--- a/src/experiment/honeycomb.js
+++ b/src/experiment/honeycomb.js
@@ -1,10 +1,11 @@
-import { JsPsych } from "jspsych";
+import * as Types from "../lib/typedef";
 import { buildEndProcedure } from "./procedures/endProcedure";
 import { buildHoneycombProcedure } from "./procedures/honeycombProcedure";
 import { buildStartProcedure } from "./procedures/startProcedure";
 
 import { buildDebriefTrial, instructionsTrial, preloadTrial } from "./trials/honeycombTrials";
 import { buildCountdownTrial } from "./trials/countdown";
+
 
 /**
  * ! This file should not be edited! Instead, create a new file with the name of your task
@@ -33,7 +34,7 @@ export const honeycombOptions = {
  * Take a look at how the code here compares to the jsPsych documentation!
  * See the jsPsych documentation for more: https://www.jspsych.org/7.3/tutorials/rt-task/
  *
- * @param {JsPsych} jsPsych The jsPsych instance being used to run the task
+ * @param {Types.JsPsych} jsPsych The jsPsych instance being used to run the task
  * @returns {object} A jsPsych timeline object
  */
 export function buildHoneycombTimeline(jsPsych) {

--- a/src/experiment/index.js
+++ b/src/experiment/index.js
@@ -20,7 +20,7 @@ export const jsPsychOptions = honeycombOptions;
 /**
  * Builds the experiment's timeline that jsPsych will run
  * The instance of jsPsych passed in will include jsPsychOptions from above
- * @param {Object} jsPsych The jsPsych instance that is running the experiment
+ * @param {JsPsych} jsPsych The jsPsych instance that is running the experiment
  * @param {string} studyID The ID of the study that was just logged into
  * @param {string} participantID The ID of the participant that was just logged in
  * @returns The timeline for JsPsych to run

--- a/src/experiment/index.js
+++ b/src/experiment/index.js
@@ -9,8 +9,6 @@ import "jspsych/css/jspsych.css";
 // Add custom CSS styling for this task
 import "../lib/markup/trials.css";
 
-import * as Types from "../lib/typedef";
-
 /**
  * Experiment-wide settings for jsPsych: https://www.jspsych.org/7.3/overview/experiment-options/
  * Note that Honeycomb combines these with other options required for Honeycomb to operate correctly
@@ -22,7 +20,7 @@ export const jsPsychOptions = honeycombOptions;
 /**
  * Builds the experiment's timeline that jsPsych will run
  * The instance of jsPsych passed in will include jsPsychOptions from above
- * @param {Types.JsPsych} jsPsych The jsPsych instance that is running the experiment
+ * @param {JsPsych} jsPsych The jsPsych instance that is running the experiment
  * @param {string} studyID The ID of the study that was just logged into
  * @param {string} participantID The ID of the participant that was just logged in
  * @returns The timeline for JsPsych to run

--- a/src/experiment/index.js
+++ b/src/experiment/index.js
@@ -9,6 +9,8 @@ import "jspsych/css/jspsych.css";
 // Add custom CSS styling for this task
 import "../lib/markup/trials.css";
 
+import * as Types from "../lib/typedef";
+
 /**
  * Experiment-wide settings for jsPsych: https://www.jspsych.org/7.3/overview/experiment-options/
  * Note that Honeycomb combines these with other options required for Honeycomb to operate correctly
@@ -20,7 +22,7 @@ export const jsPsychOptions = honeycombOptions;
 /**
  * Builds the experiment's timeline that jsPsych will run
  * The instance of jsPsych passed in will include jsPsychOptions from above
- * @param {JsPsych} jsPsych The jsPsych instance that is running the experiment
+ * @param {Types.JsPsych} jsPsych The jsPsych instance that is running the experiment
  * @param {string} studyID The ID of the study that was just logged into
  * @param {string} participantID The ID of the participant that was just logged in
  * @returns The timeline for JsPsych to run

--- a/src/experiment/procedures/endProcedure.js
+++ b/src/experiment/procedures/endProcedure.js
@@ -1,3 +1,4 @@
+import { JsPsych } from "jspsych";
 import { config } from "../../config/main";
 import { buildCameraEndTrial } from "../trials/camera";
 import { conclusionTrial } from "../trials/conclusion";
@@ -8,7 +9,7 @@ import { exitFullscreenTrial } from "../trials/fullscreen";
  * 1) Trial used to complete the user's camera recording is displayed
  * 2) The experiment exits fullscreen
  *
- * @param {Object} jsPsych The jsPsych instance being used to run the task
+ * @param {JsPsych} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych (nested) timeline object
  */
 export function buildEndProcedure(jsPsych) {

--- a/src/experiment/procedures/endProcedure.js
+++ b/src/experiment/procedures/endProcedure.js
@@ -1,15 +1,15 @@
-import { JsPsych } from "jspsych";
 import { config } from "../../config/main";
 import { buildCameraEndTrial } from "../trials/camera";
 import { conclusionTrial } from "../trials/conclusion";
 import { exitFullscreenTrial } from "../trials/fullscreen";
+import * as Types from "../../lib/typedef";
 
 /**
  * Builds the procedure needed to end the experiment
  * 1) Trial used to complete the user's camera recording is displayed
  * 2) The experiment exits fullscreen
  *
- * @param {JsPsych} jsPsych The jsPsych instance being used to run the task
+ * @param {Types.JsPsych} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych (nested) timeline object
  */
 export function buildEndProcedure(jsPsych) {

--- a/src/experiment/procedures/endProcedure.js
+++ b/src/experiment/procedures/endProcedure.js
@@ -2,14 +2,13 @@ import { config } from "../../config/main";
 import { buildCameraEndTrial } from "../trials/camera";
 import { conclusionTrial } from "../trials/conclusion";
 import { exitFullscreenTrial } from "../trials/fullscreen";
-import * as Types from "../../lib/typedef";
 
 /**
  * Builds the procedure needed to end the experiment
  * 1) Trial used to complete the user's camera recording is displayed
  * 2) The experiment exits fullscreen
  *
- * @param {Types.JsPsych} jsPsych The jsPsych instance being used to run the task
+ * @param {JsPsych} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych (nested) timeline object
  */
 export function buildEndProcedure(jsPsych) {

--- a/src/experiment/procedures/honeycombProcedure.js
+++ b/src/experiment/procedures/honeycombProcedure.js
@@ -4,7 +4,6 @@ import { config, SETTINGS } from "../../config/main";
 import { eventCodes } from "../../config/trigger";
 import { pdSpotEncode, photodiodeGhostBox } from "../../lib/markup/photodiode";
 import { buildFixationTrial } from "../trials/fixation";
-import * as Types from "../../lib/typedef";
 
 /**
  * Builds the block of trials that form the core of the Honeycomb experiment
@@ -13,7 +12,7 @@ import * as Types from "../../lib/typedef";
  *
  * Note that the block is conditionally rendered and repeated based on the task settings
  *
- * @param {Types.JsPsych} jsPsych The jsPsych instance being used to run the task
+ * @param {JsPsych} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych (nested) timeline object
  */
 export function buildHoneycombProcedure(jsPsych) {

--- a/src/experiment/procedures/honeycombProcedure.js
+++ b/src/experiment/procedures/honeycombProcedure.js
@@ -1,4 +1,5 @@
 import imageKeyboardResponse from "@jspsych/plugin-image-keyboard-response";
+import { JsPsych } from "jspsych";
 
 import { config, SETTINGS } from "../../config/main";
 import { eventCodes } from "../../config/trigger";
@@ -12,7 +13,7 @@ import { buildFixationTrial } from "../trials/fixation";
  *
  * Note that the block is conditionally rendered and repeated based on the task settings
  *
- * @param {Object} jsPsych The jsPsych instance being used to run the task
+ * @param {JsPsych} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych (nested) timeline object
  */
 export function buildHoneycombProcedure(jsPsych) {

--- a/src/experiment/procedures/honeycombProcedure.js
+++ b/src/experiment/procedures/honeycombProcedure.js
@@ -1,10 +1,10 @@
 import imageKeyboardResponse from "@jspsych/plugin-image-keyboard-response";
-import { JsPsych } from "jspsych";
 
 import { config, SETTINGS } from "../../config/main";
 import { eventCodes } from "../../config/trigger";
 import { pdSpotEncode, photodiodeGhostBox } from "../../lib/markup/photodiode";
 import { buildFixationTrial } from "../trials/fixation";
+import * as Types from "../../lib/typedef";
 
 /**
  * Builds the block of trials that form the core of the Honeycomb experiment
@@ -13,7 +13,7 @@ import { buildFixationTrial } from "../trials/fixation";
  *
  * Note that the block is conditionally rendered and repeated based on the task settings
  *
- * @param {JsPsych} jsPsych The jsPsych instance being used to run the task
+ * @param {Types.JsPsych} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych (nested) timeline object
  */
 export function buildHoneycombProcedure(jsPsych) {

--- a/src/experiment/procedures/startProcedure.js
+++ b/src/experiment/procedures/startProcedure.js
@@ -7,8 +7,6 @@ import { nameTrial } from "../trials/name";
 import { initPhotodiodeTrial } from "../trials/initPhotodiode";
 import { introductionTrial } from "../trials/introduction";
 
-import * as Types from "../../lib/typedef";
-
 /**
  * Builds the block of trials needed to start and setup the experiment
  * 1) The name of the experiment is displayed

--- a/src/experiment/procedures/startProcedure.js
+++ b/src/experiment/procedures/startProcedure.js
@@ -1,3 +1,4 @@
+import { JsPsych } from "jspsych";
 import { config } from "../../config/main";
 
 import { buildCameraStartTrial } from "../trials/camera";
@@ -15,7 +16,7 @@ import { introductionTrial } from "../trials/introduction";
  * 4) Trials used to set up a photodiode and trigger box are displayed (if applicable)
  * 5) Trials used to set up the user's camera are displayed (if applicable)
  *
- * @param {Object} jsPsych The jsPsych instance being used to run the task
+ * @param {JsPsych} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych (nested) timeline object
  */
 export function buildStartProcedure(jsPsych) {

--- a/src/experiment/procedures/startProcedure.js
+++ b/src/experiment/procedures/startProcedure.js
@@ -1,4 +1,3 @@
-import { JsPsych } from "jspsych";
 import { config } from "../../config/main";
 
 import { buildCameraStartTrial } from "../trials/camera";
@@ -8,6 +7,8 @@ import { nameTrial } from "../trials/name";
 import { initPhotodiodeTrial } from "../trials/initPhotodiode";
 import { introductionTrial } from "../trials/introduction";
 
+import * as Types from "../../lib/typedef";
+
 /**
  * Builds the block of trials needed to start and setup the experiment
  * 1) The name of the experiment is displayed
@@ -16,7 +17,7 @@ import { introductionTrial } from "../trials/introduction";
  * 4) Trials used to set up a photodiode and trigger box are displayed (if applicable)
  * 5) Trials used to set up the user's camera are displayed (if applicable)
  *
- * @param {JsPsych} jsPsych The jsPsych instance being used to run the task
+ * @param {Types.JsPsych} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych (nested) timeline object
  */
 export function buildStartProcedure(jsPsych) {

--- a/src/experiment/procedures/startProcedure.js
+++ b/src/experiment/procedures/startProcedure.js
@@ -15,7 +15,7 @@ import { introductionTrial } from "../trials/introduction";
  * 4) Trials used to set up a photodiode and trigger box are displayed (if applicable)
  * 5) Trials used to set up the user's camera are displayed (if applicable)
  *
- * @param {Types.JsPsych} jsPsych The jsPsych instance being used to run the task
+ * @param {JsPsych} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych (nested) timeline object
  */
 export function buildStartProcedure(jsPsych) {

--- a/src/experiment/trials/camera.js
+++ b/src/experiment/trials/camera.js
@@ -9,7 +9,7 @@ const WEBCAM_ID = "webcam";
 
 /**
  * A trial that begins recording the participant using their computer's default camera
- * @param {Object} jsPsych The jsPsych instance being used to run the task
+ * @param {JsPsych} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych trial object
  */
 // TODO @brown-ccv #301: Use jsPsych extension, deprecate this function

--- a/src/experiment/trials/fixation.js
+++ b/src/experiment/trials/fixation.js
@@ -1,14 +1,13 @@
 import htmlKeyboardResponse from "@jspsych/plugin-html-keyboard-response";
-import { JsPsych } from "jspsych";
-
 import { SETTINGS, config } from "../../config/main";
 import { eventCodes } from "../../config/trigger";
 import { pdSpotEncode, photodiodeGhostBox } from "../../lib/markup/photodiode";
 import { div } from "../../lib/markup/tags";
+import * as Types from "../../lib/typedef";
 
 /**
  * Builds a trial with a fixation dot and optional photodiode box.
- * @param {JsPsych} jsPsych The global jsPsych object used to build the trial
+ * @param {Types.JsPsych} jsPsych The global jsPsych object used to build the trial
  * @returns {Object} A jsPsych trial object
  */
 export function buildFixationTrial(jsPsych) {

--- a/src/experiment/trials/fixation.js
+++ b/src/experiment/trials/fixation.js
@@ -1,4 +1,5 @@
 import htmlKeyboardResponse from "@jspsych/plugin-html-keyboard-response";
+import { JsPsych } from "jspsych";
 
 import { SETTINGS, config } from "../../config/main";
 import { eventCodes } from "../../config/trigger";
@@ -7,7 +8,7 @@ import { div } from "../../lib/markup/tags";
 
 /**
  * Builds a trial with a fixation dot and optional photodiode box.
- * @param {Object} jsPsych The global jsPsych object used to build the trial
+ * @param {JsPsych} jsPsych The global jsPsych object used to build the trial
  * @returns {Object} A jsPsych trial object
  */
 export function buildFixationTrial(jsPsych) {

--- a/src/experiment/trials/fixation.js
+++ b/src/experiment/trials/fixation.js
@@ -3,11 +3,10 @@ import { SETTINGS, config } from "../../config/main";
 import { eventCodes } from "../../config/trigger";
 import { pdSpotEncode, photodiodeGhostBox } from "../../lib/markup/photodiode";
 import { div } from "../../lib/markup/tags";
-import * as Types from "../../lib/typedef";
 
 /**
  * Builds a trial with a fixation dot and optional photodiode box.
- * @param {Types.JsPsych} jsPsych The global jsPsych object used to build the trial
+ * @param {JsPsych} jsPsych The global jsPsych object used to build the trial
  * @returns {Object} A jsPsych trial object
  */
 export function buildFixationTrial(jsPsych) {

--- a/src/lib/typedef.js
+++ b/src/lib/typedef.js
@@ -1,0 +1,1 @@
+/** @typedef {import("jspsych").JsPsych} JsPsych */

--- a/src/lib/typedef.js
+++ b/src/lib/typedef.js
@@ -1,1 +1,3 @@
 /** @typedef {import("jspsych").JsPsych} JsPsych */
+
+export const Types = {};

--- a/src/lib/typedef.js
+++ b/src/lib/typedef.js
@@ -1,3 +1,1 @@
 /** @typedef {import("jspsych").JsPsych} JsPsych */
-
-export const Types = {};


### PR DESCRIPTION
* created `typedef.js` file in `src/lib` 
* moved `JsPsych` type from gearshift into this file
* update `eslint` to include `typedef.js`
* update documentation in `index.js` for `buildTimeLine` function from general object to `JsPsych` 
  * should we in this same PR, update all these general object to `JsPsych` type for`@param` documentations for functions where it's applicable? 