### PR TITLE
Add get random element

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -111,3 +111,13 @@ export function getSeconds(ms) {
 export function getTimeString(ms) {
   return `${getMinute(ms)}:${getSeconds(ms).toString().padStart(2, "0")}`;
 }
+
+/**
+ * Randomly retrieves a single element from an array
+ * @param {JsPsych} jsPsych The jsPsych instance being used to run the task
+ * @param {Array} array A given array of elements
+ * @returns
+ */
+export function getRandomElement(jsPsych, array) {
+  return jsPsych.randomization.sampleWithoutReplacement(array, 1)[0];
+}


### PR DESCRIPTION
I found the `getRandomElement` function in this repo that seems like a version of gearshift [repo](https://github.com/brown-ccv/jehli-gearshift-task/blob/6844fe4d837c01d06a19f77f572027a72965f27e/src/lib/utils.js#L97)

I'm guessing that this utilities function is still the same; please let me know if anything needs to be changed or if this function should be moved somewhere else : ) 

Also changed the general `object` type to `JsPsych` since we will define that in `typedef.js` 