### PR TITLE
refactor: holdUpMarker as basic trial to line up photodiode spot and …

### DIFF
--- a/src/experiment/honeycomb.js
+++ b/src/experiment/honeycomb.js
@@ -53,8 +53,8 @@ export function buildHoneycombTimeline(jsPsych) {
 
   const timeline = [
     startProcedure,
-    countdownTrial,
     preloadTrial,
+    countdownTrial,
     instructionsTrial,
     honeycombProcedure,
     debriefTrial,

--- a/src/experiment/trials/holdUpMarker.js
+++ b/src/experiment/trials/holdUpMarker.js
@@ -1,32 +1,13 @@
 import htmlButtonResponse from "@jspsych/plugin-html-button-response";
+import { LANGUAGE } from "../../config/main";
+import { h1 } from "../../lib/markup/tags";
+import { photodiodeGhostBox } from "../../lib/markup/photodiode";
 
-import { config, LANGUAGE } from "../../config/main";
-import { eventCodes } from "../../config/trigger";
-import { pdSpotEncode, photodiodeGhostBox } from "../../lib/markup/photodiode";
-import { div, h1, p } from "../../lib/markup/tags";
-
-// TODO @brown-ccv #330: Custom extension for EEG - this is initializeTriggerBox
-// TODO @brown-ccv #330: Need to ping the serial part - this isn't doing anything yet
-// TODO @brown-ccv: Prevent user from pressing continue until pdSpotEncode finishes (need to use jsPsych.pluginAPI.setTimeout)
 export const holdUpMarkerTrial = {
   type: htmlButtonResponse,
-  stimulus: function () {
-    const eventMarkerMarkup = h1(LANGUAGE.trials.eventMarker.connected, {
-      style: "color: green;",
-    });
-    return div(eventMarkerMarkup);
-  },
-  prompt: function () {
-    let holdUpMarkerPrompt = p(LANGUAGE.trials.holdUpMarker);
-
-    // Conditionally add the photodiodeGhostBox
-    if (config.USE_PHOTODIODE) holdUpMarkerPrompt += photodiodeGhostBox;
-
-    return holdUpMarkerPrompt;
-  },
+  stimulus:
+    h1(LANGUAGE.trials.eventMarker.connected, { style: "color: green;" }) +
+    h1(LANGUAGE.trials.holdUpMarker) +
+    photodiodeGhostBox,
   choices: [LANGUAGE.prompts.continue.button],
-  on_load: function () {
-    // Conditionally flash the photodiode when the trial first loads
-    if (config.USE_PHOTODIODE) pdSpotEncode(eventCodes.test_connect);
-  },
 };

--- a/src/experiment/trials/holdUpMarker.js
+++ b/src/experiment/trials/holdUpMarker.js
@@ -6,7 +6,6 @@ import { photodiodeGhostBox } from "../../lib/markup/photodiode";
 export const holdUpMarkerTrial = {
   type: htmlButtonResponse,
   stimulus:
-    h1(LANGUAGE.trials.eventMarker.connected, { style: "color: green;" }) +
     h1(LANGUAGE.trials.holdUpMarker) +
     photodiodeGhostBox,
   choices: [LANGUAGE.prompts.continue.button],


### PR DESCRIPTION
* Move `holdUpMarker` code in to change original to a basic trial 
* Move `countdownTrial` to before `preloadTrial` in the timeline so the countdown will begin after serialport pop-up box (all set-up completed)  