### PR TITLE
Ref event codes json

### DIFF
--- a/src/config/eventCodes.json
+++ b/src/config/eventCodes.json
@@ -1,0 +1,6 @@
+{
+  "fixation": 1,
+  "honeycomb": 2,
+  "open_task": 18,
+  "test_connect": 32
+}

--- a/src/config/trigger.js
+++ b/src/config/trigger.js
@@ -1,3 +1,5 @@
+import event_codes from "./eventCodes.json";
+
 // TODO @brown-ccv #333: Nest this data under "trigger_box" equipment in config.json
 
 // teensyduino
@@ -13,12 +15,7 @@ export const comName = import.meta.env.EVENT_MARKER_COM_NAME || "COM3";
 
 /** Custom codes for specific task events - used to identify the trials */
 // TODO @brown-ccv #354: Each event should have a code, name, and numBlinks
-export const eventCodes = {
-  fixation: 1, // Fixation trial
-  honeycomb: 2, // Main reaction-time trial for the Honeycomb task
-  open_task: 18, // Opening task for setting up the experiment
-  test_connect: 32, // Initial test connection
-};
+export const eventCodes = event_codes;
 
 // TODO: We should think of a cleaner way of exporting all this
 export const trigger = {


### PR DESCRIPTION
- moved `eventCodes` into its own json file 
- change import/export in `trigger.js` accordingly 
- should we rename the final export in `trigger.js` `EVENT_CODES` instead of `eventCodes`? Also not entirely sure if we want to name this file `config.json` as mentioned in the issue or `eventCodes.json` 

- merged into `ref-config-env-idx` since a lot of the changes there are related to this modification; this branch was also based on `ref-config-env-idx`. This can also be changed to base on `v4` branch if needed.  