### PR TITLE
jsPsych as global variable

### DIFF
--- a/src/App/components/JsPsychExperiment.jsx
+++ b/src/App/components/JsPsychExperiment.jsx
@@ -67,6 +67,7 @@ export default function JsPsychExperiment({
    */
   React.useEffect(() => {
     if (jsPsych) {
+      // set jsPsych object as global variable
       window.jsPsych = jsPsych;
       const timeline = buildTimeline(studyID, participantID);
       jsPsych.run(timeline);

--- a/src/App/components/JsPsychExperiment.jsx
+++ b/src/App/components/JsPsychExperiment.jsx
@@ -5,6 +5,7 @@ import React from "react";
 import { ENV } from "../../config/";
 import { buildTimeline, jsPsychOptions } from "../../experiment";
 import { initParticipant } from "../deployments/firebase";
+import { getJsPsych } from "../../lib/utils";
 
 // ID used to identify the DOM element that holds the experiment.
 const EXPERIMENT_ID = "experiment-window";
@@ -70,7 +71,7 @@ export default function JsPsychExperiment({
       // set up jsPsych object as global variable
       window.jsPsych = jsPsych;
       const timeline = buildTimeline(studyID, participantID);
-      window.jsPsych.run(timeline);
+      getJsPsych().run(timeline);
     }
   }, [jsPsych]);
 

--- a/src/App/components/JsPsychExperiment.jsx
+++ b/src/App/components/JsPsychExperiment.jsx
@@ -70,7 +70,7 @@ export default function JsPsychExperiment({
       // set up jsPsych object as global variable
       window.jsPsych = jsPsych;
       const timeline = buildTimeline(studyID, participantID);
-      jsPsych.run(timeline);
+      window.jsPsych.run(timeline);
     }
   }, [jsPsych]);
 

--- a/src/App/components/JsPsychExperiment.jsx
+++ b/src/App/components/JsPsychExperiment.jsx
@@ -67,7 +67,7 @@ export default function JsPsychExperiment({
    */
   React.useEffect(() => {
     if (jsPsych) {
-      // set jsPsych object as global variable
+      // set up jsPsych object as global variable
       window.jsPsych = jsPsych;
       const timeline = buildTimeline(studyID, participantID);
       jsPsych.run(timeline);

--- a/src/App/components/JsPsychExperiment.jsx
+++ b/src/App/components/JsPsychExperiment.jsx
@@ -51,7 +51,7 @@ export default function JsPsychExperiment({
       tempJsPsych.data.addProperties({
         app_name: import.meta.env.PACKAGE_NAME,
         app_version: import.meta.env.PACKAGE_VERSION,
-        // app_commit: await window.electronAPI.getCommit(),
+        app_commit: await window.electronAPI.getCommit(),
         study_id: studyID,
         participant_id: participantID,
         start_date: startDate,

--- a/src/App/components/JsPsychExperiment.jsx
+++ b/src/App/components/JsPsychExperiment.jsx
@@ -51,7 +51,7 @@ export default function JsPsychExperiment({
       tempJsPsych.data.addProperties({
         app_name: import.meta.env.PACKAGE_NAME,
         app_version: import.meta.env.PACKAGE_VERSION,
-        app_commit: await window.electronAPI.getCommit(),
+        // app_commit: await window.electronAPI.getCommit(),
         study_id: studyID,
         participant_id: participantID,
         start_date: startDate,
@@ -67,7 +67,8 @@ export default function JsPsychExperiment({
    */
   React.useEffect(() => {
     if (jsPsych) {
-      const timeline = buildTimeline(jsPsych, studyID, participantID);
+      window.jsPsych = jsPsych;
+      const timeline = buildTimeline(studyID, participantID);
       jsPsych.run(timeline);
     }
   }, [jsPsych]);

--- a/src/experiment/honeycomb.js
+++ b/src/experiment/honeycomb.js
@@ -31,10 +31,9 @@ export const honeycombOptions = {
  * Take a look at how the code here compares to the jsPsych documentation!
  * See the jsPsych documentation for more: https://www.jspsych.org/7.3/tutorials/rt-task/
  *
- * @param {Object} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych timeline object
  */
-export function buildHoneycombTimeline() {
+export const buildHoneycombTimeline = () => {
   // Build the trials that make up the start procedure
   const startProcedure = buildStartProcedure();
 
@@ -42,7 +41,7 @@ export function buildHoneycombTimeline() {
   const honeycombProcedure = buildHoneycombProcedure();
 
   // Builds the trial needed to debrief the participant on their performance
-  const debriefTrial = buildDebriefTrial();
+  const debriefTrial = buildDebriefTrial;
 
   // Builds the trials that make up the end procedure
   const endProcedure = buildEndProcedure();
@@ -56,4 +55,4 @@ export function buildHoneycombTimeline() {
     endProcedure,
   ];
   return timeline;
-}
+};

--- a/src/experiment/honeycomb.js
+++ b/src/experiment/honeycomb.js
@@ -34,12 +34,14 @@ export const honeycombOptions = {
  * @param {Object} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych timeline object
  */
-export function buildHoneycombTimeline(jsPsych) {
+export function buildHoneycombTimeline() {
+  const jsPsych = window.jsPsych;
+  console.log(jsPsych);
   // Build the trials that make up the start procedure
-  const startProcedure = buildStartProcedure(jsPsych);
+  const startProcedure = buildStartProcedure();
 
   // Build the trials that make up the task procedure
-  const honeycombProcedure = buildHoneycombProcedure(jsPsych);
+  const honeycombProcedure = buildHoneycombProcedure();
 
   // Builds the trial needed to debrief the participant on their performance
   const debriefTrial = buildDebriefTrial(jsPsych);

--- a/src/experiment/honeycomb.js
+++ b/src/experiment/honeycomb.js
@@ -35,8 +35,6 @@ export const honeycombOptions = {
  * @returns {Object} A jsPsych timeline object
  */
 export function buildHoneycombTimeline() {
-  const jsPsych = window.jsPsych;
-  console.log(jsPsych);
   // Build the trials that make up the start procedure
   const startProcedure = buildStartProcedure();
 
@@ -44,10 +42,10 @@ export function buildHoneycombTimeline() {
   const honeycombProcedure = buildHoneycombProcedure();
 
   // Builds the trial needed to debrief the participant on their performance
-  const debriefTrial = buildDebriefTrial(jsPsych);
+  const debriefTrial = buildDebriefTrial();
 
   // Builds the trials that make up the end procedure
-  const endProcedure = buildEndProcedure(jsPsych);
+  const endProcedure = buildEndProcedure();
 
   const timeline = [
     startProcedure,

--- a/src/experiment/index.js
+++ b/src/experiment/index.js
@@ -25,13 +25,13 @@ export const jsPsychOptions = honeycombOptions;
  * @param {string} participantID The ID of the participant that was just logged in
  * @returns The timeline for JsPsych to run
  */
-export function buildTimeline(jsPsych, studyID, participantID) {
+export function buildTimeline(studyID, participantID) {
   console.log(`Building timeline for participant ${participantID} on study ${studyID}`);
 
   /**
    * ! Your timeline should be built in a newly created function, not this one
    * https://brown-ccv.github.io/honeycomb-docs/docs/quick_start#2-add-a-file-for-the-task
    */
-  const timeline = buildHoneycombTimeline(jsPsych);
+  const timeline = buildHoneycombTimeline();
   return timeline;
 }

--- a/src/experiment/procedures/endProcedure.js
+++ b/src/experiment/procedures/endProcedure.js
@@ -8,15 +8,14 @@ import { exitFullscreenTrial } from "../trials/fullscreen";
  * 1) Trial used to complete the user's camera recording is displayed
  * 2) The experiment exits fullscreen
  *
- * @param {Object} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych (nested) timeline object
  */
-export function buildEndProcedure() {
+export const buildEndProcedure = () => {
   const procedure = [];
 
   // Conditionally add the camera breakdown trials
   if (ENV.USE_CAMERA) {
-    procedure.push(buildCameraEndTrial());
+    procedure.push(buildCameraEndTrial);
   }
 
   // Add the other trials needed to end the experiment
@@ -24,4 +23,4 @@ export function buildEndProcedure() {
 
   // Return the block as a nested timeline
   return { timeline: procedure };
-}
+};

--- a/src/experiment/procedures/endProcedure.js
+++ b/src/experiment/procedures/endProcedure.js
@@ -11,12 +11,12 @@ import { exitFullscreenTrial } from "../trials/fullscreen";
  * @param {Object} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych (nested) timeline object
  */
-export function buildEndProcedure(jsPsych) {
+export function buildEndProcedure() {
   const procedure = [];
 
   // Conditionally add the camera breakdown trials
   if (ENV.USE_CAMERA) {
-    procedure.push(buildCameraEndTrial(jsPsych));
+    procedure.push(buildCameraEndTrial());
   }
 
   // Add the other trials needed to end the experiment

--- a/src/experiment/procedures/endProcedure.js
+++ b/src/experiment/procedures/endProcedure.js
@@ -8,7 +8,6 @@ import { exitFullscreenTrial } from "../trials/fullscreen";
  * 1) Trial used to complete the user's camera recording is displayed
  * 2) The experiment exits fullscreen
  *
- * @param {Object} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych (nested) timeline object
  */
 export function buildEndProcedure() {

--- a/src/experiment/procedures/honeycombProcedure.js
+++ b/src/experiment/procedures/honeycombProcedure.js
@@ -18,10 +18,6 @@ import { buildFixationTrial } from "../trials/fixation";
 export function buildHoneycombProcedure() {
   const honeycombSettings = SETTINGS.honeycomb;
   const fixationTrial = buildFixationTrial();
-
-  console.log("use window.jspsych in procedure");
-  console.log(window.jsPsych);
-
   /**
    * Displays a colored circle and waits for participant to response with a keyboard press
    *

--- a/src/experiment/procedures/honeycombProcedure.js
+++ b/src/experiment/procedures/honeycombProcedure.js
@@ -69,5 +69,3 @@ export function buildHoneycombProcedure() {
   };
   return honeycombBlock;
 }
-
-// TODO have constant honeycomb procedure, all functions that don't need parameters can be objects

--- a/src/experiment/procedures/honeycombProcedure.js
+++ b/src/experiment/procedures/honeycombProcedure.js
@@ -15,10 +15,10 @@ import { buildFixationTrial } from "../trials/fixation";
  * @param {Object} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych (nested) timeline object
  */
-export function buildHoneycombProcedure(jsPsych) {
+export function buildHoneycombProcedure() {
   const honeycombSettings = SETTINGS.honeycomb;
-
-  const fixationTrial = buildFixationTrial(jsPsych);
+  console.log("hi");
+  const fixationTrial = buildFixationTrial();
 
   /**
    * Displays a colored circle and waits for participant to response with a keyboard press
@@ -31,7 +31,7 @@ export function buildHoneycombProcedure(jsPsych) {
   const taskTrial = {
     type: imageKeyboardResponse,
     // Display the image passed as a timeline variable
-    stimulus: jsPsych.timelineVariable("stimulus"),
+    stimulus: window.jsPsych.timelineVariable("stimulus"),
     prompt: function () {
       // Conditionally displays the photodiodeGhostBox
       if (ENV.USE_PHOTODIODE) return photodiodeGhostBox;
@@ -42,7 +42,7 @@ export function buildHoneycombProcedure(jsPsych) {
     data: {
       // Record the correct_response passed as a timeline variable
       code: eventCodes.honeycomb,
-      correct_response: jsPsych.timelineVariable("correct_response"),
+      correct_response: window.jsPsych.timelineVariable("correct_response"),
     },
     on_load: function () {
       // Conditionally flashes the photodiode when the trial first loads
@@ -50,7 +50,7 @@ export function buildHoneycombProcedure(jsPsych) {
     },
     // Add a boolean value ("correct") to the data - if the user responded with the correct key or not
     on_finish: function (data) {
-      data.correct = jsPsych.pluginAPI.compareKeys(data.response, data.correct_response);
+      data.correct = window.jsPsych.pluginAPI.compareKeys(data.response, data.correct_response);
     },
   };
 

--- a/src/experiment/procedures/honeycombProcedure.js
+++ b/src/experiment/procedures/honeycombProcedure.js
@@ -12,12 +12,11 @@ import { buildFixationTrial } from "../trials/fixation";
  *
  * Note that the block is conditionally rendered and repeated based on the task settings
  *
- * @param {Object} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych (nested) timeline object
  */
-export function buildHoneycombProcedure() {
+export const buildHoneycombProcedure = () => {
   const honeycombSettings = SETTINGS.honeycomb;
-  const fixationTrial = buildFixationTrial();
+  const fixationTrial = buildFixationTrial;
   /**
    * Displays a colored circle and waits for participant to response with a keyboard press
    *
@@ -68,4 +67,4 @@ export function buildHoneycombProcedure() {
     timeline: [fixationTrial, taskTrial],
   };
   return honeycombBlock;
-}
+};

--- a/src/experiment/procedures/honeycombProcedure.js
+++ b/src/experiment/procedures/honeycombProcedure.js
@@ -17,8 +17,10 @@ import { buildFixationTrial } from "../trials/fixation";
  */
 export function buildHoneycombProcedure() {
   const honeycombSettings = SETTINGS.honeycomb;
-  console.log("hi");
   const fixationTrial = buildFixationTrial();
+
+  console.log("use window.jspsych in procedure");
+  console.log(window.jsPsych);
 
   /**
    * Displays a colored circle and waits for participant to response with a keyboard press
@@ -71,3 +73,5 @@ export function buildHoneycombProcedure() {
   };
   return honeycombBlock;
 }
+
+// TODO have constant honeycomb procedure, all functions that don't need parameters can be objects

--- a/src/experiment/procedures/honeycombProcedure.js
+++ b/src/experiment/procedures/honeycombProcedure.js
@@ -4,6 +4,7 @@ import { ENV, SETTINGS } from "../../config/";
 import { eventCodes } from "../../config/trigger";
 import { pdSpotEncode, photodiodeGhostBox } from "../../lib/markup/photodiode";
 import { buildFixationTrial } from "../trials/fixation";
+import { getJsPsych } from "../../lib/utils";
 
 /**
  * Builds the block of trials that form the core of the Honeycomb experiment
@@ -12,7 +13,6 @@ import { buildFixationTrial } from "../trials/fixation";
  *
  * Note that the block is conditionally rendered and repeated based on the task settings
  *
- * @param {Object} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych (nested) timeline object
  */
 export function buildHoneycombProcedure() {
@@ -29,7 +29,7 @@ export function buildHoneycombProcedure() {
   const taskTrial = {
     type: imageKeyboardResponse,
     // Display the image passed as a timeline variable
-    stimulus: window.jsPsych.timelineVariable("stimulus"),
+    stimulus: getJsPsych().timelineVariable("stimulus"),
     prompt: function () {
       // Conditionally displays the photodiodeGhostBox
       if (ENV.USE_PHOTODIODE) return photodiodeGhostBox;
@@ -40,7 +40,7 @@ export function buildHoneycombProcedure() {
     data: {
       // Record the correct_response passed as a timeline variable
       code: eventCodes.honeycomb,
-      correct_response: window.jsPsych.timelineVariable("correct_response"),
+      correct_response: getJsPsych().timelineVariable("correct_response"),
     },
     on_load: function () {
       // Conditionally flashes the photodiode when the trial first loads
@@ -48,7 +48,7 @@ export function buildHoneycombProcedure() {
     },
     // Add a boolean value ("correct") to the data - if the user responded with the correct key or not
     on_finish: function (data) {
-      data.correct = window.jsPsych.pluginAPI.compareKeys(data.response, data.correct_response);
+      data.correct = getJsPsych().pluginAPI.compareKeys(data.response, data.correct_response);
     },
   };
 

--- a/src/experiment/procedures/startProcedure.js
+++ b/src/experiment/procedures/startProcedure.js
@@ -15,10 +15,9 @@ import { introductionTrial } from "../trials/introduction";
  * 4) Trials used to set up a photodiode and trigger box are displayed (if applicable)
  * 5) Trials used to set up the user's camera are displayed (if applicable)
  *
- * @param {Object} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych (nested) timeline object
  */
-export function buildStartProcedure() {
+export const buildStartProcedure = () => {
   const procedure = [nameTrial, enterFullscreenTrial, introductionTrial];
 
   // Conditionally add the photodiode setup trials
@@ -29,9 +28,9 @@ export function buildStartProcedure() {
 
   // Conditionally add the camera setup trials
   if (ENV.USE_CAMERA) {
-    procedure.push(buildCameraStartTrial());
+    procedure.push(buildCameraStartTrial);
   }
 
   // Return the block as a nested timeline
   return { timeline: procedure };
-}
+};

--- a/src/experiment/procedures/startProcedure.js
+++ b/src/experiment/procedures/startProcedure.js
@@ -15,7 +15,6 @@ import { introductionTrial } from "../trials/introduction";
  * 4) Trials used to set up a photodiode and trigger box are displayed (if applicable)
  * 5) Trials used to set up the user's camera are displayed (if applicable)
  *
- * @param {Object} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych (nested) timeline object
  */
 export function buildStartProcedure() {

--- a/src/experiment/procedures/startProcedure.js
+++ b/src/experiment/procedures/startProcedure.js
@@ -18,7 +18,7 @@ import { introductionTrial } from "../trials/introduction";
  * @param {Object} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych (nested) timeline object
  */
-export function buildStartProcedure(jsPsych) {
+export function buildStartProcedure() {
   const procedure = [nameTrial, enterFullscreenTrial, introductionTrial];
 
   // Conditionally add the photodiode setup trials
@@ -29,7 +29,7 @@ export function buildStartProcedure(jsPsych) {
 
   // Conditionally add the camera setup trials
   if (ENV.USE_CAMERA) {
-    procedure.push(buildCameraStartTrial(jsPsych));
+    procedure.push(buildCameraStartTrial());
   }
 
   // Return the block as a nested timeline

--- a/src/experiment/trials/camera.js
+++ b/src/experiment/trials/camera.js
@@ -9,111 +9,105 @@ const WEBCAM_ID = "webcam";
 
 /**
  * A trial that begins recording the participant using their computer's default camera
- * @param {Object} jsPsych The jsPsych instance being used to run the task
+ *
  * @returns {Object} A jsPsych trial object
  */
 // TODO @brown-ccv #301: Use jsPsych extension, deprecate this function
 // TODO @brown-ccv #343: We should be able to make this work on both electron and browser?
 // TODO @brown-ccv #301: Rolling save to the deployment (webm is a subset of mkv)
-export function buildCameraStartTrial() {
-  return {
-    timeline: [
-      {
-        // Prompts user permission for camera device
-        type: initializeCamera,
-        include_audio: true,
-        mime_type: "video/webm",
+export const buildCameraStartTrial = {
+  timeline: [
+    {
+      // Prompts user permission for camera device
+      type: initializeCamera,
+      include_audio: true,
+      mime_type: "video/webm",
+    },
+    {
+      // Helps participant center themselves inside the camera
+      type: htmlButtonResponse,
+      stimulus: function () {
+        const videoMarkup = tag("video", "", {
+          id: WEBCAM_ID,
+          width: 640,
+          height: 480,
+          autoplay: true,
+        });
+        const cameraStartMarkup = p(LANGUAGE.trials.camera.start);
+        const trialMarkup = div(cameraStartMarkup + videoMarkup, {
+          class: "align-items-center-col",
+        });
+        return div(trialMarkup);
       },
-      {
-        // Helps participant center themselves inside the camera
-        type: htmlButtonResponse,
-        stimulus: function () {
-          const videoMarkup = tag("video", "", {
-            id: WEBCAM_ID,
-            width: 640,
-            height: 480,
-            autoplay: true,
-          });
-          const cameraStartMarkup = p(LANGUAGE.trials.camera.start);
-          const trialMarkup = div(cameraStartMarkup + videoMarkup, {
-            class: "align-items-center-col",
-          });
-          return div(trialMarkup);
-        },
-        choices: [LANGUAGE.prompts.continue.button],
-        response_ends_trial: true,
-        on_start: function () {
-          // Initialize and store the camera feed
-          if (!ENV.USE_ELECTRON) {
-            throw new Error("video recording is only available when running inside Electron");
-          }
+      choices: [LANGUAGE.prompts.continue.button],
+      response_ends_trial: true,
+      on_start: function () {
+        // Initialize and store the camera feed
+        if (!ENV.USE_ELECTRON) {
+          throw new Error("video recording is only available when running inside Electron");
+        }
 
-          const cameraRecorder = window.jsPsych.pluginAPI.getCameraRecorder();
-          if (!cameraRecorder) {
-            console.error("Camera is not initialized, no data will be recorded.");
-            return;
-          }
-          const cameraChunks = [];
+        const cameraRecorder = window.jsPsych.pluginAPI.getCameraRecorder();
+        if (!cameraRecorder) {
+          console.error("Camera is not initialized, no data will be recorded.");
+          return;
+        }
+        const cameraChunks = [];
 
-          // Push data whenever available
-          cameraRecorder.addEventListener("dataavailable", (event) => {
-            if (event.data.size > 0) cameraChunks.push(event.data);
-          });
+        // Push data whenever available
+        cameraRecorder.addEventListener("dataavailable", (event) => {
+          if (event.data.size > 0) cameraChunks.push(event.data);
+        });
 
-          // Saves the raw data feed from the participants camera (executed on cameraRecorder.stop()).
-          cameraRecorder.addEventListener("stop", () => {
-            const blob = new Blob(cameraChunks, { type: cameraRecorder.mimeType });
+        // Saves the raw data feed from the participants camera (executed on cameraRecorder.stop()).
+        cameraRecorder.addEventListener("stop", () => {
+          const blob = new Blob(cameraChunks, { type: cameraRecorder.mimeType });
 
-            // Pass video data to Electron as a base64 encoded string
-            const reader = new FileReader();
-            reader.readAsDataURL(blob);
-            reader.onloadend = () => {
-              window.electronAPI.saveVideo(reader.result);
-            };
-          });
-        },
-        on_load: function () {
-          // Assign camera feed to the <video> element
-          const camera = document.getElementById(WEBCAM_ID);
-
-          camera.srcObject = window.jsPsych.pluginAPI.getCameraRecorder().stream;
-        },
-        on_finish: function () {
-          // Begin video recording
-          window.jsPsych.pluginAPI.getCameraRecorder().start();
-        },
+          // Pass video data to Electron as a base64 encoded string
+          const reader = new FileReader();
+          reader.readAsDataURL(blob);
+          reader.onloadend = () => {
+            window.electronAPI.saveVideo(reader.result);
+          };
+        });
       },
-    ],
-  };
-}
+      on_load: function () {
+        // Assign camera feed to the <video> element
+        const camera = document.getElementById(WEBCAM_ID);
+
+        camera.srcObject = window.jsPsych.pluginAPI.getCameraRecorder().stream;
+      },
+      on_finish: function () {
+        // Begin video recording
+        window.jsPsych.pluginAPI.getCameraRecorder().start();
+      },
+    },
+  ],
+};
 
 /**
  * A trial that finishes recording the participant using their computer's default camera
  *
- * @param {Number} duration How long to show the trial for
  * @returns {Object} A jsPsych trial object
  */
-export function buildCameraEndTrial() {
-  const recordingEndMarkup = h1(LANGUAGE.trials.camera.end);
+const recordingEndMarkup = h1(LANGUAGE.trials.camera.end);
+export const buildCameraEndTrial = {
+  type: htmlKeyboardResponse,
+  stimulus: div(recordingEndMarkup),
+  trial_duration: 5000,
+  on_start: function () {
+    // Complete the camera recording
 
-  return {
-    type: htmlKeyboardResponse,
-    stimulus: div(recordingEndMarkup),
-    trial_duration: 5000,
-    on_start: function () {
-      // Complete the camera recording
+    if (!ENV.USE_ELECTRON) {
+      throw new Error("video recording is only available when running inside Electron");
+    }
 
-      if (!ENV.USE_ELECTRON) {
-        throw new Error("video recording is only available when running inside Electron");
-      }
+    const cameraRecorder = window.jsPsych.pluginAPI.getCameraRecorder();
+    if (!cameraRecorder) {
+      console.error("Camera is not initialized, no data will be recorded.");
+      return;
+    }
 
-      const cameraRecorder = window.jsPsych.pluginAPI.getCameraRecorder();
-      if (!cameraRecorder) {
-        console.error("Camera is not initialized, no data will be recorded.");
-        return;
-      }
-
-      cameraRecorder.stop();
-    },
-  };
-}
+    cameraRecorder.stop();
+  },
+};

--- a/src/experiment/trials/camera.js
+++ b/src/experiment/trials/camera.js
@@ -90,7 +90,7 @@ const recordingEndMarkup = h1(LANGUAGE.trials.camera.end);
 /**
  * A trial that finishes recording the participant using their computer's default camera
  *
- * @returns {Object} A jsPsych trial object
+ * @type {Object} A jsPsych trial object
  */
 export const buildCameraEndTrial = {
   type: htmlKeyboardResponse,

--- a/src/experiment/trials/camera.js
+++ b/src/experiment/trials/camera.js
@@ -4,6 +4,7 @@ import initializeCamera from "@jspsych/plugin-initialize-camera";
 
 import { LANGUAGE, ENV } from "../../config/";
 import { div, h1, p, tag } from "../../lib/markup/tags";
+import { getJsPsych } from "../../lib/utils";
 
 const WEBCAM_ID = "webcam";
 
@@ -48,7 +49,7 @@ export function buildCameraStartTrial() {
             throw new Error("video recording is only available when running inside Electron");
           }
 
-          const cameraRecorder = window.jsPsych.pluginAPI.getCameraRecorder();
+          const cameraRecorder = getJsPsych().pluginAPI.getCameraRecorder();
           if (!cameraRecorder) {
             console.error("Camera is not initialized, no data will be recorded.");
             return;
@@ -76,11 +77,11 @@ export function buildCameraStartTrial() {
           // Assign camera feed to the <video> element
           const camera = document.getElementById(WEBCAM_ID);
 
-          camera.srcObject = window.jsPsych.pluginAPI.getCameraRecorder().stream;
+          camera.srcObject = getJsPsych().pluginAPI.getCameraRecorder().stream;
         },
         on_finish: function () {
           // Begin video recording
-          window.jsPsych.pluginAPI.getCameraRecorder().start();
+          getJsPsych().pluginAPI.getCameraRecorder().start();
         },
       },
     ],
@@ -107,7 +108,7 @@ export function buildCameraEndTrial() {
         throw new Error("video recording is only available when running inside Electron");
       }
 
-      const cameraRecorder = window.jsPsych.pluginAPI.getCameraRecorder();
+      const cameraRecorder = getJsPsych().pluginAPI.getCameraRecorder();
       if (!cameraRecorder) {
         console.error("Camera is not initialized, no data will be recorded.");
         return;

--- a/src/experiment/trials/camera.js
+++ b/src/experiment/trials/camera.js
@@ -85,12 +85,13 @@ export const buildCameraStartTrial = {
   ],
 };
 
+const recordingEndMarkup = h1(LANGUAGE.trials.camera.end);
+
 /**
  * A trial that finishes recording the participant using their computer's default camera
  *
  * @returns {Object} A jsPsych trial object
  */
-const recordingEndMarkup = h1(LANGUAGE.trials.camera.end);
 export const buildCameraEndTrial = {
   type: htmlKeyboardResponse,
   stimulus: div(recordingEndMarkup),

--- a/src/experiment/trials/camera.js
+++ b/src/experiment/trials/camera.js
@@ -10,9 +10,9 @@ const WEBCAM_ID = "webcam";
 /**
  * A trial that begins recording the participant using their computer's default camera
  *
- * @returns {Object} A jsPsych trial object
+ * @type {Object} A jsPsych trial object
  */
-// TODO @brown-ccv #301: Use jsPsych extension, deprecate this function
+// TODO @brown-ccv #301: Use jsPsych extension, deprecate this variable
 // TODO @brown-ccv #343: We should be able to make this work on both electron and browser?
 // TODO @brown-ccv #301: Rolling save to the deployment (webm is a subset of mkv)
 export const buildCameraStartTrial = {

--- a/src/experiment/trials/camera.js
+++ b/src/experiment/trials/camera.js
@@ -15,7 +15,7 @@ const WEBCAM_ID = "webcam";
 // TODO @brown-ccv #301: Use jsPsych extension, deprecate this function
 // TODO @brown-ccv #343: We should be able to make this work on both electron and browser?
 // TODO @brown-ccv #301: Rolling save to the deployment (webm is a subset of mkv)
-export function buildCameraStartTrial(jsPsych) {
+export function buildCameraStartTrial() {
   return {
     timeline: [
       {
@@ -48,7 +48,7 @@ export function buildCameraStartTrial(jsPsych) {
             throw new Error("video recording is only available when running inside Electron");
           }
 
-          const cameraRecorder = jsPsych.pluginAPI.getCameraRecorder();
+          const cameraRecorder = window.jsPsych.pluginAPI.getCameraRecorder();
           if (!cameraRecorder) {
             console.error("Camera is not initialized, no data will be recorded.");
             return;
@@ -76,11 +76,11 @@ export function buildCameraStartTrial(jsPsych) {
           // Assign camera feed to the <video> element
           const camera = document.getElementById(WEBCAM_ID);
 
-          camera.srcObject = jsPsych.pluginAPI.getCameraRecorder().stream;
+          camera.srcObject = window.jsPsych.pluginAPI.getCameraRecorder().stream;
         },
         on_finish: function () {
           // Begin video recording
-          jsPsych.pluginAPI.getCameraRecorder().start();
+          window.jsPsych.pluginAPI.getCameraRecorder().start();
         },
       },
     ],
@@ -93,7 +93,7 @@ export function buildCameraStartTrial(jsPsych) {
  * @param {Number} duration How long to show the trial for
  * @returns {Object} A jsPsych trial object
  */
-export function buildCameraEndTrial(jsPsych) {
+export function buildCameraEndTrial() {
   const recordingEndMarkup = h1(LANGUAGE.trials.camera.end);
 
   return {
@@ -107,7 +107,7 @@ export function buildCameraEndTrial(jsPsych) {
         throw new Error("video recording is only available when running inside Electron");
       }
 
-      const cameraRecorder = jsPsych.pluginAPI.getCameraRecorder();
+      const cameraRecorder = window.jsPsych.pluginAPI.getCameraRecorder();
       if (!cameraRecorder) {
         console.error("Camera is not initialized, no data will be recorded.");
         return;

--- a/src/experiment/trials/fixation.js
+++ b/src/experiment/trials/fixation.js
@@ -4,6 +4,7 @@ import { SETTINGS, ENV } from "../../config/";
 import { eventCodes } from "../../config/trigger";
 import { pdSpotEncode, photodiodeGhostBox } from "../../lib/markup/photodiode";
 import { div } from "../../lib/markup/tags";
+import { getJsPsych } from "../../lib/utils";
 
 /**
  * Builds a trial with a fixation dot and optional photodiode box.
@@ -27,7 +28,7 @@ export function buildFixationTrial() {
     trial_duration: function () {
       if (fixationSettings.randomize_duration) {
         // Select a random duration from the durations array to show the fixation dot for
-        return window.jsPsych.randomization.sampleWithoutReplacement(
+        return getJsPsych().randomization.sampleWithoutReplacement(
           fixationSettings.durations,
           1
         )[0];

--- a/src/experiment/trials/fixation.js
+++ b/src/experiment/trials/fixation.js
@@ -5,43 +5,41 @@ import { eventCodes } from "../../config/trigger";
 import { pdSpotEncode, photodiodeGhostBox } from "../../lib/markup/photodiode";
 import { div } from "../../lib/markup/tags";
 
+const fixationSettings = SETTINGS.fixation;
+const fixationCode = eventCodes.fixation;
+
 /**
  * Builds a trial with a fixation dot and optional photodiode box.
- * @param {Object} jsPsych The global jsPsych object used to build the trial
+ *
  * @returns {Object} A jsPsych trial object
  */
-export function buildFixationTrial() {
-  const fixationSettings = SETTINGS.fixation;
-  const fixationCode = eventCodes.fixation;
-
-  return {
-    type: htmlKeyboardResponse,
-    choices: "NO_KEYS",
-    // Display the fixation dot
-    stimulus: div("", { id: "fixation-dot" }),
-    prompt: function () {
-      // Conditionally display the photodiodeGhostBox
-      if (ENV.USE_PHOTODIODE) return photodiodeGhostBox;
-      else return null;
-    },
-    trial_duration: function () {
-      if (fixationSettings.randomize_duration) {
-        // Select a random duration from the durations array to show the fixation dot for
-        return window.jsPsych.randomization.sampleWithoutReplacement(
-          fixationSettings.durations,
-          1
-        )[0];
-      } else {
-        // Show the fixation dot for default duration seconds
-        return fixationSettings.default_duration;
-      }
-    },
-    data: {
-      code: fixationCode, // Add event code to the recorded data
-    },
-    on_load: function () {
-      // Conditionally flash the photodiode when the trial first loads
-      if (ENV.USE_PHOTODIODE) pdSpotEncode(fixationCode);
-    },
-  };
-}
+export const buildFixationTrial = {
+  type: htmlKeyboardResponse,
+  choices: "NO_KEYS",
+  // Display the fixation dot
+  stimulus: div("", { id: "fixation-dot" }),
+  prompt: function () {
+    // Conditionally display the photodiodeGhostBox
+    if (ENV.USE_PHOTODIODE) return photodiodeGhostBox;
+    else return null;
+  },
+  trial_duration: function () {
+    if (fixationSettings.randomize_duration) {
+      // Select a random duration from the durations array to show the fixation dot for
+      return window.jsPsych.randomization.sampleWithoutReplacement(
+        fixationSettings.durations,
+        1
+      )[0];
+    } else {
+      // Show the fixation dot for default duration seconds
+      return fixationSettings.default_duration;
+    }
+  },
+  data: {
+    code: fixationCode, // Add event code to the recorded data
+  },
+  on_load: function () {
+    // Conditionally flash the photodiode when the trial first loads
+    if (ENV.USE_PHOTODIODE) pdSpotEncode(fixationCode);
+  },
+};

--- a/src/experiment/trials/fixation.js
+++ b/src/experiment/trials/fixation.js
@@ -11,7 +11,7 @@ const fixationCode = eventCodes.fixation;
 /**
  * Builds a trial with a fixation dot and optional photodiode box.
  *
- * @returns {Object} A jsPsych trial object
+ * @type {Object} A jsPsych trial object
  */
 export const buildFixationTrial = {
   type: htmlKeyboardResponse,

--- a/src/experiment/trials/fixation.js
+++ b/src/experiment/trials/fixation.js
@@ -10,7 +10,7 @@ import { div } from "../../lib/markup/tags";
  * @param {Object} jsPsych The global jsPsych object used to build the trial
  * @returns {Object} A jsPsych trial object
  */
-export function buildFixationTrial(jsPsych) {
+export function buildFixationTrial() {
   const fixationSettings = SETTINGS.fixation;
   const fixationCode = eventCodes.fixation;
 
@@ -27,7 +27,10 @@ export function buildFixationTrial(jsPsych) {
     trial_duration: function () {
       if (fixationSettings.randomize_duration) {
         // Select a random duration from the durations array to show the fixation dot for
-        return jsPsych.randomization.sampleWithoutReplacement(fixationSettings.durations, 1)[0];
+        return window.jsPsych.randomization.sampleWithoutReplacement(
+          fixationSettings.durations,
+          1
+        )[0];
       } else {
         // Show the fixation dot for default duration seconds
         return fixationSettings.default_duration;

--- a/src/experiment/trials/honeycombTrials.js
+++ b/src/experiment/trials/honeycombTrials.js
@@ -5,6 +5,7 @@ import preloadResponse from "@jspsych/plugin-preload";
 import { LANGUAGE, SETTINGS } from "../../config/";
 import { eventCodes } from "../../config/trigger";
 import { b, div, image, p } from "../../lib/markup/tags";
+import { getJsPsych } from "../../lib/utils";
 
 const honeycombLanguage = LANGUAGE.trials.honeycomb;
 
@@ -61,7 +62,7 @@ export function buildDebriefTrial() {
        * By accessing jsPsych inside the "stimulus" callback we have access to all of the data when this trial is run
        * Calling jsPsych outside of the trial object would be executed to soon (when the experiment first starts) and would therefore have no data
        */
-      const responseTrials = window.jsPsych.data.get().filter({ code: eventCodes.honeycomb });
+      const responseTrials = getJsPsych().data.get().filter({ code: eventCodes.honeycomb });
       const correct_trials = responseTrials.filter({ correct: true });
       const accuracy = Math.round((correct_trials.count() / responseTrials.count()) * 100);
       const reactionTime = Math.round(correct_trials.select("rt").mean());

--- a/src/experiment/trials/honeycombTrials.js
+++ b/src/experiment/trials/honeycombTrials.js
@@ -52,7 +52,7 @@ export const preloadTrial = {
 };
 
 /** Trial that calculates and displays some results of the session  */
-export function buildDebriefTrial(jsPsych) {
+export function buildDebriefTrial() {
   return {
     type: htmlKeyboardResponse,
     stimulus: function () {
@@ -61,7 +61,7 @@ export function buildDebriefTrial(jsPsych) {
        * By accessing jsPsych inside the "stimulus" callback we have access to all of the data when this trial is run
        * Calling jsPsych outside of the trial object would be executed to soon (when the experiment first starts) and would therefore have no data
        */
-      const responseTrials = jsPsych.data.get().filter({ code: eventCodes.honeycomb });
+      const responseTrials = window.jsPsych.data.get().filter({ code: eventCodes.honeycomb });
       const correct_trials = responseTrials.filter({ correct: true });
       const accuracy = Math.round((correct_trials.count() / responseTrials.count()) * 100);
       const reactionTime = Math.round(correct_trials.select("rt").mean());

--- a/src/experiment/trials/honeycombTrials.js
+++ b/src/experiment/trials/honeycombTrials.js
@@ -52,31 +52,29 @@ export const preloadTrial = {
 };
 
 /** Trial that calculates and displays some results of the session  */
-export function buildDebriefTrial() {
-  return {
-    type: htmlKeyboardResponse,
-    stimulus: function () {
-      /**
-       * Note that we need the jsPsych instance to aggregate the data.
-       * By accessing jsPsych inside the "stimulus" callback we have access to all of the data when this trial is run
-       * Calling jsPsych outside of the trial object would be executed to soon (when the experiment first starts) and would therefore have no data
-       */
-      const responseTrials = window.jsPsych.data.get().filter({ code: eventCodes.honeycomb });
-      const correct_trials = responseTrials.filter({ correct: true });
-      const accuracy = Math.round((correct_trials.count() / responseTrials.count()) * 100);
-      const reactionTime = Math.round(correct_trials.select("rt").mean());
-      const debriefLanguage = honeycombLanguage.debrief;
+export const buildDebriefTrial = {
+  type: htmlKeyboardResponse,
+  stimulus: function () {
+    /**
+     * Note that we need the jsPsych instance to aggregate the data.
+     * By accessing jsPsych inside the "stimulus" callback we have access to all of the data when this trial is run
+     * Calling jsPsych outside of the trial object would be executed to soon (when the experiment first starts) and would therefore have no data
+     */
+    const responseTrials = window.jsPsych.data.get().filter({ code: eventCodes.honeycomb });
+    const correct_trials = responseTrials.filter({ correct: true });
+    const accuracy = Math.round((correct_trials.count() / responseTrials.count()) * 100);
+    const reactionTime = Math.round(correct_trials.select("rt").mean());
+    const debriefLanguage = honeycombLanguage.debrief;
 
-      const accuracyMarkup = p(
-        debriefLanguage.accuracy.start + accuracy + debriefLanguage.accuracy.end
-      );
-      const reactionTimeMarkup = p(
-        debriefLanguage.reactionTime.start + reactionTime + debriefLanguage.reactionTime.end
-      );
-      const completeMarkup = p(debriefLanguage.complete);
+    const accuracyMarkup = p(
+      debriefLanguage.accuracy.start + accuracy + debriefLanguage.accuracy.end
+    );
+    const reactionTimeMarkup = p(
+      debriefLanguage.reactionTime.start + reactionTime + debriefLanguage.reactionTime.end
+    );
+    const completeMarkup = p(debriefLanguage.complete);
 
-      // Display the accuracy, reaction time, and complete message as 3 paragraphs in a row
-      return accuracyMarkup + reactionTimeMarkup + completeMarkup;
-    },
-  };
-}
+    // Display the accuracy, reaction time, and complete message as 3 paragraphs in a row
+    return accuracyMarkup + reactionTimeMarkup + completeMarkup;
+  },
+};

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -81,3 +81,7 @@ export function getProlificId() {
 export function interleave(arr, val, addBefore = true) {
   return [].concat(...arr.map((n) => (addBefore ? [val, n] : [n, val])));
 }
+
+export function getJsPscyh() {
+  return "hi";
+}

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -81,7 +81,3 @@ export function getProlificId() {
 export function interleave(arr, val, addBefore = true) {
   return [].concat(...arr.map((n) => (addBefore ? [val, n] : [n, val])));
 }
-
-export function getJsPscyh() {
-  return "hi";
-}

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -81,3 +81,12 @@ export function getProlificId() {
 export function interleave(arr, val, addBefore = true) {
   return [].concat(...arr.map((n) => (addBefore ? [val, n] : [n, val])));
 }
+
+/**
+ * Get global JsPsych instance
+ *
+ * @returns JsPsych instance
+ */
+export function getJsPsych() {
+  return window.jsPsych;
+}


### PR DESCRIPTION
- when `jsPsych` instance gets initialized, set global variable `window.jsPsych` to this object 
- remove all function argument that takes in `jsPsych` object
- refactor all usage of `jsPsych` into `window.jsPsych` to be accessed globally 
- add util function to get and return the global `jsPsych` instance
- tested code under different setting (clinic, home, browser, with video) 