### PR TITLE
ref: change all func taking in jspsych to const syntax / trials to co…

### DIFF
--- a/src/experiment/honeycomb.js
+++ b/src/experiment/honeycomb.js
@@ -31,10 +31,9 @@ export const honeycombOptions = {
  * Take a look at how the code here compares to the jsPsych documentation!
  * See the jsPsych documentation for more: https://www.jspsych.org/7.3/tutorials/rt-task/
  *
- * @param {Object} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych timeline object
  */
-export function buildHoneycombTimeline() {
+export const buildHoneycombTimeline = () => {
   // Build the trials that make up the start procedure
   const startProcedure = buildStartProcedure();
 
@@ -42,7 +41,7 @@ export function buildHoneycombTimeline() {
   const honeycombProcedure = buildHoneycombProcedure();
 
   // Builds the trial needed to debrief the participant on their performance
-  const debriefTrial = buildDebriefTrial();
+  const debriefTrial = buildDebriefTrial;
 
   // Builds the trials that make up the end procedure
   const endProcedure = buildEndProcedure();
@@ -56,4 +55,4 @@ export function buildHoneycombTimeline() {
     endProcedure,
   ];
   return timeline;
-}
+};

--- a/src/experiment/procedures/endProcedure.js
+++ b/src/experiment/procedures/endProcedure.js
@@ -8,15 +8,14 @@ import { exitFullscreenTrial } from "../trials/fullscreen";
  * 1) Trial used to complete the user's camera recording is displayed
  * 2) The experiment exits fullscreen
  *
- * @param {Object} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych (nested) timeline object
  */
-export function buildEndProcedure() {
+export const buildEndProcedure = () => {
   const procedure = [];
 
   // Conditionally add the camera breakdown trials
   if (ENV.USE_CAMERA) {
-    procedure.push(buildCameraEndTrial());
+    procedure.push(buildCameraEndTrial);
   }
 
   // Add the other trials needed to end the experiment
@@ -24,4 +23,4 @@ export function buildEndProcedure() {
 
   // Return the block as a nested timeline
   return { timeline: procedure };
-}
+};

--- a/src/experiment/procedures/honeycombProcedure.js
+++ b/src/experiment/procedures/honeycombProcedure.js
@@ -12,12 +12,11 @@ import { buildFixationTrial } from "../trials/fixation";
  *
  * Note that the block is conditionally rendered and repeated based on the task settings
  *
- * @param {Object} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych (nested) timeline object
  */
-export function buildHoneycombProcedure() {
+export const buildHoneycombProcedure = () => {
   const honeycombSettings = SETTINGS.honeycomb;
-  const fixationTrial = buildFixationTrial();
+  const fixationTrial = buildFixationTrial;
   /**
    * Displays a colored circle and waits for participant to response with a keyboard press
    *
@@ -68,4 +67,4 @@ export function buildHoneycombProcedure() {
     timeline: [fixationTrial, taskTrial],
   };
   return honeycombBlock;
-}
+};

--- a/src/experiment/procedures/startProcedure.js
+++ b/src/experiment/procedures/startProcedure.js
@@ -15,10 +15,9 @@ import { introductionTrial } from "../trials/introduction";
  * 4) Trials used to set up a photodiode and trigger box are displayed (if applicable)
  * 5) Trials used to set up the user's camera are displayed (if applicable)
  *
- * @param {Object} jsPsych The jsPsych instance being used to run the task
  * @returns {Object} A jsPsych (nested) timeline object
  */
-export function buildStartProcedure() {
+export const buildStartProcedure = () => {
   const procedure = [nameTrial, enterFullscreenTrial, introductionTrial];
 
   // Conditionally add the photodiode setup trials
@@ -29,9 +28,9 @@ export function buildStartProcedure() {
 
   // Conditionally add the camera setup trials
   if (ENV.USE_CAMERA) {
-    procedure.push(buildCameraStartTrial());
+    procedure.push(buildCameraStartTrial);
   }
 
   // Return the block as a nested timeline
   return { timeline: procedure };
-}
+};

--- a/src/experiment/trials/camera.js
+++ b/src/experiment/trials/camera.js
@@ -9,111 +9,105 @@ const WEBCAM_ID = "webcam";
 
 /**
  * A trial that begins recording the participant using their computer's default camera
- * @param {Object} jsPsych The jsPsych instance being used to run the task
+ *
  * @returns {Object} A jsPsych trial object
  */
 // TODO @brown-ccv #301: Use jsPsych extension, deprecate this function
 // TODO @brown-ccv #343: We should be able to make this work on both electron and browser?
 // TODO @brown-ccv #301: Rolling save to the deployment (webm is a subset of mkv)
-export function buildCameraStartTrial() {
-  return {
-    timeline: [
-      {
-        // Prompts user permission for camera device
-        type: initializeCamera,
-        include_audio: true,
-        mime_type: "video/webm",
+export const buildCameraStartTrial = {
+  timeline: [
+    {
+      // Prompts user permission for camera device
+      type: initializeCamera,
+      include_audio: true,
+      mime_type: "video/webm",
+    },
+    {
+      // Helps participant center themselves inside the camera
+      type: htmlButtonResponse,
+      stimulus: function () {
+        const videoMarkup = tag("video", "", {
+          id: WEBCAM_ID,
+          width: 640,
+          height: 480,
+          autoplay: true,
+        });
+        const cameraStartMarkup = p(LANGUAGE.trials.camera.start);
+        const trialMarkup = div(cameraStartMarkup + videoMarkup, {
+          class: "align-items-center-col",
+        });
+        return div(trialMarkup);
       },
-      {
-        // Helps participant center themselves inside the camera
-        type: htmlButtonResponse,
-        stimulus: function () {
-          const videoMarkup = tag("video", "", {
-            id: WEBCAM_ID,
-            width: 640,
-            height: 480,
-            autoplay: true,
-          });
-          const cameraStartMarkup = p(LANGUAGE.trials.camera.start);
-          const trialMarkup = div(cameraStartMarkup + videoMarkup, {
-            class: "align-items-center-col",
-          });
-          return div(trialMarkup);
-        },
-        choices: [LANGUAGE.prompts.continue.button],
-        response_ends_trial: true,
-        on_start: function () {
-          // Initialize and store the camera feed
-          if (!ENV.USE_ELECTRON) {
-            throw new Error("video recording is only available when running inside Electron");
-          }
+      choices: [LANGUAGE.prompts.continue.button],
+      response_ends_trial: true,
+      on_start: function () {
+        // Initialize and store the camera feed
+        if (!ENV.USE_ELECTRON) {
+          throw new Error("video recording is only available when running inside Electron");
+        }
 
-          const cameraRecorder = window.jsPsych.pluginAPI.getCameraRecorder();
-          if (!cameraRecorder) {
-            console.error("Camera is not initialized, no data will be recorded.");
-            return;
-          }
-          const cameraChunks = [];
+        const cameraRecorder = window.jsPsych.pluginAPI.getCameraRecorder();
+        if (!cameraRecorder) {
+          console.error("Camera is not initialized, no data will be recorded.");
+          return;
+        }
+        const cameraChunks = [];
 
-          // Push data whenever available
-          cameraRecorder.addEventListener("dataavailable", (event) => {
-            if (event.data.size > 0) cameraChunks.push(event.data);
-          });
+        // Push data whenever available
+        cameraRecorder.addEventListener("dataavailable", (event) => {
+          if (event.data.size > 0) cameraChunks.push(event.data);
+        });
 
-          // Saves the raw data feed from the participants camera (executed on cameraRecorder.stop()).
-          cameraRecorder.addEventListener("stop", () => {
-            const blob = new Blob(cameraChunks, { type: cameraRecorder.mimeType });
+        // Saves the raw data feed from the participants camera (executed on cameraRecorder.stop()).
+        cameraRecorder.addEventListener("stop", () => {
+          const blob = new Blob(cameraChunks, { type: cameraRecorder.mimeType });
 
-            // Pass video data to Electron as a base64 encoded string
-            const reader = new FileReader();
-            reader.readAsDataURL(blob);
-            reader.onloadend = () => {
-              window.electronAPI.saveVideo(reader.result);
-            };
-          });
-        },
-        on_load: function () {
-          // Assign camera feed to the <video> element
-          const camera = document.getElementById(WEBCAM_ID);
-
-          camera.srcObject = window.jsPsych.pluginAPI.getCameraRecorder().stream;
-        },
-        on_finish: function () {
-          // Begin video recording
-          window.jsPsych.pluginAPI.getCameraRecorder().start();
-        },
+          // Pass video data to Electron as a base64 encoded string
+          const reader = new FileReader();
+          reader.readAsDataURL(blob);
+          reader.onloadend = () => {
+            window.electronAPI.saveVideo(reader.result);
+          };
+        });
       },
-    ],
-  };
-}
+      on_load: function () {
+        // Assign camera feed to the <video> element
+        const camera = document.getElementById(WEBCAM_ID);
+
+        camera.srcObject = window.jsPsych.pluginAPI.getCameraRecorder().stream;
+      },
+      on_finish: function () {
+        // Begin video recording
+        window.jsPsych.pluginAPI.getCameraRecorder().start();
+      },
+    },
+  ],
+};
 
 /**
  * A trial that finishes recording the participant using their computer's default camera
  *
- * @param {Number} duration How long to show the trial for
  * @returns {Object} A jsPsych trial object
  */
-export function buildCameraEndTrial() {
-  const recordingEndMarkup = h1(LANGUAGE.trials.camera.end);
+const recordingEndMarkup = h1(LANGUAGE.trials.camera.end);
+export const buildCameraEndTrial = {
+  type: htmlKeyboardResponse,
+  stimulus: div(recordingEndMarkup),
+  trial_duration: 5000,
+  on_start: function () {
+    // Complete the camera recording
 
-  return {
-    type: htmlKeyboardResponse,
-    stimulus: div(recordingEndMarkup),
-    trial_duration: 5000,
-    on_start: function () {
-      // Complete the camera recording
+    if (!ENV.USE_ELECTRON) {
+      throw new Error("video recording is only available when running inside Electron");
+    }
 
-      if (!ENV.USE_ELECTRON) {
-        throw new Error("video recording is only available when running inside Electron");
-      }
+    const cameraRecorder = window.jsPsych.pluginAPI.getCameraRecorder();
+    if (!cameraRecorder) {
+      console.error("Camera is not initialized, no data will be recorded.");
+      return;
+    }
 
-      const cameraRecorder = window.jsPsych.pluginAPI.getCameraRecorder();
-      if (!cameraRecorder) {
-        console.error("Camera is not initialized, no data will be recorded.");
-        return;
-      }
-
-      cameraRecorder.stop();
-    },
-  };
-}
+    cameraRecorder.stop();
+  },
+};

--- a/src/experiment/trials/camera.js
+++ b/src/experiment/trials/camera.js
@@ -90,7 +90,7 @@ const recordingEndMarkup = h1(LANGUAGE.trials.camera.end);
 /**
  * A trial that finishes recording the participant using their computer's default camera
  *
- * @returns {Object} A jsPsych trial object
+ * @type {Object} A jsPsych trial object
  */
 export const buildCameraEndTrial = {
   type: htmlKeyboardResponse,

--- a/src/experiment/trials/camera.js
+++ b/src/experiment/trials/camera.js
@@ -85,12 +85,13 @@ export const buildCameraStartTrial = {
   ],
 };
 
+const recordingEndMarkup = h1(LANGUAGE.trials.camera.end);
+
 /**
  * A trial that finishes recording the participant using their computer's default camera
  *
  * @returns {Object} A jsPsych trial object
  */
-const recordingEndMarkup = h1(LANGUAGE.trials.camera.end);
 export const buildCameraEndTrial = {
   type: htmlKeyboardResponse,
   stimulus: div(recordingEndMarkup),

--- a/src/experiment/trials/camera.js
+++ b/src/experiment/trials/camera.js
@@ -10,9 +10,9 @@ const WEBCAM_ID = "webcam";
 /**
  * A trial that begins recording the participant using their computer's default camera
  *
- * @returns {Object} A jsPsych trial object
+ * @type {Object} A jsPsych trial object
  */
-// TODO @brown-ccv #301: Use jsPsych extension, deprecate this function
+// TODO @brown-ccv #301: Use jsPsych extension, deprecate this variable
 // TODO @brown-ccv #343: We should be able to make this work on both electron and browser?
 // TODO @brown-ccv #301: Rolling save to the deployment (webm is a subset of mkv)
 export const buildCameraStartTrial = {

--- a/src/experiment/trials/fixation.js
+++ b/src/experiment/trials/fixation.js
@@ -5,43 +5,41 @@ import { eventCodes } from "../../config/trigger";
 import { pdSpotEncode, photodiodeGhostBox } from "../../lib/markup/photodiode";
 import { div } from "../../lib/markup/tags";
 
+const fixationSettings = SETTINGS.fixation;
+const fixationCode = eventCodes.fixation;
+
 /**
  * Builds a trial with a fixation dot and optional photodiode box.
- * @param {Object} jsPsych The global jsPsych object used to build the trial
+ *
  * @returns {Object} A jsPsych trial object
  */
-export function buildFixationTrial() {
-  const fixationSettings = SETTINGS.fixation;
-  const fixationCode = eventCodes.fixation;
-
-  return {
-    type: htmlKeyboardResponse,
-    choices: "NO_KEYS",
-    // Display the fixation dot
-    stimulus: div("", { id: "fixation-dot" }),
-    prompt: function () {
-      // Conditionally display the photodiodeGhostBox
-      if (ENV.USE_PHOTODIODE) return photodiodeGhostBox;
-      else return null;
-    },
-    trial_duration: function () {
-      if (fixationSettings.randomize_duration) {
-        // Select a random duration from the durations array to show the fixation dot for
-        return window.jsPsych.randomization.sampleWithoutReplacement(
-          fixationSettings.durations,
-          1
-        )[0];
-      } else {
-        // Show the fixation dot for default duration seconds
-        return fixationSettings.default_duration;
-      }
-    },
-    data: {
-      code: fixationCode, // Add event code to the recorded data
-    },
-    on_load: function () {
-      // Conditionally flash the photodiode when the trial first loads
-      if (ENV.USE_PHOTODIODE) pdSpotEncode(fixationCode);
-    },
-  };
-}
+export const buildFixationTrial = {
+  type: htmlKeyboardResponse,
+  choices: "NO_KEYS",
+  // Display the fixation dot
+  stimulus: div("", { id: "fixation-dot" }),
+  prompt: function () {
+    // Conditionally display the photodiodeGhostBox
+    if (ENV.USE_PHOTODIODE) return photodiodeGhostBox;
+    else return null;
+  },
+  trial_duration: function () {
+    if (fixationSettings.randomize_duration) {
+      // Select a random duration from the durations array to show the fixation dot for
+      return window.jsPsych.randomization.sampleWithoutReplacement(
+        fixationSettings.durations,
+        1
+      )[0];
+    } else {
+      // Show the fixation dot for default duration seconds
+      return fixationSettings.default_duration;
+    }
+  },
+  data: {
+    code: fixationCode, // Add event code to the recorded data
+  },
+  on_load: function () {
+    // Conditionally flash the photodiode when the trial first loads
+    if (ENV.USE_PHOTODIODE) pdSpotEncode(fixationCode);
+  },
+};

--- a/src/experiment/trials/fixation.js
+++ b/src/experiment/trials/fixation.js
@@ -11,7 +11,7 @@ const fixationCode = eventCodes.fixation;
 /**
  * Builds a trial with a fixation dot and optional photodiode box.
  *
- * @returns {Object} A jsPsych trial object
+ * @type {Object} A jsPsych trial object
  */
 export const buildFixationTrial = {
   type: htmlKeyboardResponse,

--- a/src/experiment/trials/honeycombTrials.js
+++ b/src/experiment/trials/honeycombTrials.js
@@ -52,31 +52,29 @@ export const preloadTrial = {
 };
 
 /** Trial that calculates and displays some results of the session  */
-export function buildDebriefTrial() {
-  return {
-    type: htmlKeyboardResponse,
-    stimulus: function () {
-      /**
-       * Note that we need the jsPsych instance to aggregate the data.
-       * By accessing jsPsych inside the "stimulus" callback we have access to all of the data when this trial is run
-       * Calling jsPsych outside of the trial object would be executed to soon (when the experiment first starts) and would therefore have no data
-       */
-      const responseTrials = window.jsPsych.data.get().filter({ code: eventCodes.honeycomb });
-      const correct_trials = responseTrials.filter({ correct: true });
-      const accuracy = Math.round((correct_trials.count() / responseTrials.count()) * 100);
-      const reactionTime = Math.round(correct_trials.select("rt").mean());
-      const debriefLanguage = honeycombLanguage.debrief;
+export const buildDebriefTrial = {
+  type: htmlKeyboardResponse,
+  stimulus: function () {
+    /**
+     * Note that we need the jsPsych instance to aggregate the data.
+     * By accessing jsPsych inside the "stimulus" callback we have access to all of the data when this trial is run
+     * Calling jsPsych outside of the trial object would be executed to soon (when the experiment first starts) and would therefore have no data
+     */
+    const responseTrials = window.jsPsych.data.get().filter({ code: eventCodes.honeycomb });
+    const correct_trials = responseTrials.filter({ correct: true });
+    const accuracy = Math.round((correct_trials.count() / responseTrials.count()) * 100);
+    const reactionTime = Math.round(correct_trials.select("rt").mean());
+    const debriefLanguage = honeycombLanguage.debrief;
 
-      const accuracyMarkup = p(
-        debriefLanguage.accuracy.start + accuracy + debriefLanguage.accuracy.end
-      );
-      const reactionTimeMarkup = p(
-        debriefLanguage.reactionTime.start + reactionTime + debriefLanguage.reactionTime.end
-      );
-      const completeMarkup = p(debriefLanguage.complete);
+    const accuracyMarkup = p(
+      debriefLanguage.accuracy.start + accuracy + debriefLanguage.accuracy.end
+    );
+    const reactionTimeMarkup = p(
+      debriefLanguage.reactionTime.start + reactionTime + debriefLanguage.reactionTime.end
+    );
+    const completeMarkup = p(debriefLanguage.complete);
 
-      // Display the accuracy, reaction time, and complete message as 3 paragraphs in a row
-      return accuracyMarkup + reactionTimeMarkup + completeMarkup;
-    },
-  };
-}
+    // Display the accuracy, reaction time, and complete message as 3 paragraphs in a row
+    return accuracyMarkup + reactionTimeMarkup + completeMarkup;
+  },
+};


### PR DESCRIPTION
After removing`jsPsych` passed in as params in `jsPsych-global` branch: 
- For `procedures`: change to `const` function syntax, call functions in original place  
- For `trials`: change to `const` jsPsych trial object syntax, move variable declarations outside the object declaration when necessary 
- javadoc: remove tags requiring `jsPsych` as a parameter 
- tested with running browser, dev home, dev clinic, dev clinic with video 